### PR TITLE
Add ability to save and restore Bitmaps

### DIFF
--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -9,6 +9,8 @@ import android.support.annotation.Nullable;
 import android.util.Base64;
 import android.view.View;
 
+import com.livefront.bridge.wrapper.WrapperUtils;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -84,6 +86,7 @@ class BridgeDelegate {
         if (bundle == null) {
             return;
         }
+        WrapperUtils.unwrapOptimizedObjects(bundle);
         mSavedStateHandler.restoreInstanceState(target, bundle);
     }
 
@@ -100,6 +103,7 @@ class BridgeDelegate {
             // Don't bother saving empty bundles
             return;
         }
+        WrapperUtils.wrapOptimizedObjects(bundle);
         mUuidBundleMap.put(uuid, bundle);
         writeToDisk(uuid, bundle);
     }

--- a/bridge/src/main/java/com/livefront/bridge/wrapper/BitmapWrapper.java
+++ b/bridge/src/main/java/com/livefront/bridge/wrapper/BitmapWrapper.java
@@ -1,0 +1,61 @@
+package com.livefront.bridge.wrapper;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+
+import java.io.ByteArrayOutputStream;
+
+/**
+ * A wrapper class for a {@link Bitmap} that can be placed into a {@link android.os.Bundle} that
+ * may be written to disk.
+ */
+class BitmapWrapper implements Parcelable {
+
+    private Bitmap mBitmap;
+
+    public BitmapWrapper(@NonNull Bitmap bitmap) {
+        mBitmap = bitmap;
+    }
+
+    public Bitmap getBitmap() {
+        return mBitmap;
+    }
+
+    //region Parcelable
+    protected BitmapWrapper(Parcel in) {
+        byte[] bytes = in.createByteArray();
+        mBitmap = BitmapFactory.decodeByteArray(
+                bytes,
+                0,
+                bytes.length);
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        mBitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
+        dest.writeByteArray(stream.toByteArray());
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final Creator<BitmapWrapper> CREATOR = new Creator<BitmapWrapper>() {
+        @Override
+        public BitmapWrapper createFromParcel(Parcel in) {
+            return new BitmapWrapper(in);
+        }
+
+        @Override
+        public BitmapWrapper[] newArray(int size) {
+            return new BitmapWrapper[size];
+        }
+    };
+    //endregion Parcelable
+
+}

--- a/bridge/src/main/java/com/livefront/bridge/wrapper/WrapperUtils.java
+++ b/bridge/src/main/java/com/livefront/bridge/wrapper/WrapperUtils.java
@@ -1,0 +1,40 @@
+package com.livefront.bridge.wrapper;
+
+import android.graphics.Bitmap;
+import android.os.Bundle;
+import android.os.Parcel;
+import android.support.annotation.NonNull;
+
+import java.util.Set;
+
+/**
+ * Handles the wrapping and unwrapping of certain {@link android.os.Parcelable} objects that use
+ * native code to optimize their {@code Parcelable} implementations. When placed into a {@link
+ * Bundle} unwrapped, these objects will cause a crash if the {@code Bundle} is written to a
+ * {@link android.os.Parcel} that then calls {@link Parcel#marshall()}.
+ */
+public class WrapperUtils {
+
+    public static void unwrapOptimizedObjects(@NonNull Bundle bundle) {
+        Set<String> keys = bundle.keySet();
+        for (String key : keys) {
+            if (bundle.get(key) instanceof BitmapWrapper) {
+                BitmapWrapper bitmapWrapper = (BitmapWrapper) bundle.get(key);
+                //noinspection ConstantConditions
+                bundle.putParcelable(key, bitmapWrapper.getBitmap());
+            }
+        }
+    }
+
+    public static void wrapOptimizedObjects(@NonNull Bundle bundle) {
+        Set<String> keys = bundle.keySet();
+        for (String key : keys) {
+            if (bundle.get(key) instanceof Bitmap) {
+                Bitmap bitmap = (Bitmap) bundle.get(key);
+                //noinspection ConstantConditions
+                bundle.putParcelable(key, new BitmapWrapper(bitmap));
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
This PR adds the ability to save and restore `Bitmap` objects using `Bridge`. These need special treatment because they are written to a `Parcel` in an optimized way by calling `nativeWriteToParcel` to use native code that places a binder reference into the `Parcel` rather than raw data. These references are not allowed when calling `Parcel.marshall()` and cause a crash when trying to write the `Parcel` to disk. 

The solution here is to wrap the `Bitmap` in a new class (`BitmapWrapper`) that has a `Parcelable` implementation that simply stores the raw bytes for the `Bitmap`. This wrapping and unwrapping is handled by a new `WrapperUtils` class that may be expanded to support other "optimized" objects in the future, like `Region`, `MotionEvent`, etc.