### PR TITLE
Remove unnecessary special case for View objects

### DIFF
--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -7,7 +7,6 @@ import android.os.Parcel;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Base64;
-import android.view.View;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -38,11 +37,7 @@ class BridgeDelegate {
     }
 
     private String getKeyForUuid(@NonNull Object target) {
-        String classId = target.getClass().getName();
-        if (target instanceof View) {
-            classId += ((View) target).getId();
-        }
-        return String.format(KEY_UUID, classId);
+        return String.format(KEY_UUID, target.getClass().getName());
     }
 
     @Nullable


### PR DESCRIPTION
This PR just does a little cleanup to remove the special treatment for `View` objects when finding the key to return their UUID. This code was unnecessary because saving the state of a `View` with `Bridge` is not technically supported yet and would require additional methods in the `SavedStateHandler` interface.