### PR TITLE
Clear old data faster

### DIFF
--- a/bridge/src/main/java/com/livefront/bridge/Bridge.java
+++ b/bridge/src/main/java/com/livefront/bridge/Bridge.java
@@ -51,7 +51,7 @@ public class Bridge {
      */
     public static void restoreInstanceState(@NonNull Object target, @Nullable Bundle state) {
         checkInitialization();
-        sDelegate.restoreInstanceStateInternal(target, state);
+        sDelegate.restoreInstanceState(target, state);
     }
 
     /**
@@ -63,7 +63,7 @@ public class Bridge {
      */
     public static void saveInstanceState(@NonNull Object target, @NonNull Bundle state) {
         checkInitialization();
-        sDelegate.saveInstanceStateInternal(target, state);
+        sDelegate.saveInstanceState(target, state);
     }
 
 }

--- a/bridge/src/main/java/com/livefront/bridge/Bridge.java
+++ b/bridge/src/main/java/com/livefront/bridge/Bridge.java
@@ -29,6 +29,17 @@ public class Bridge {
     }
 
     /**
+     * Clears all data from disk and memory. Does not require a call to {@link #initialize(Context,
+     * SavedStateHandler)}.
+     */
+    public static void clearAll(@NonNull Context context) {
+        BridgeDelegate delegate = sDelegate != null
+                ? sDelegate
+                : new BridgeDelegate(context, new NoOpSavedStateHandler());
+        delegate.clearAll();
+    }
+
+    /**
      * Initializes the framework used to save and restore data and route it to a location free from
      * {@link android.os.TransactionTooLargeException}. The actual state saving and restoration
      * of each object will be performed by the provided {@link SavedStateHandler}.

--- a/bridge/src/main/java/com/livefront/bridge/Bridge.java
+++ b/bridge/src/main/java/com/livefront/bridge/Bridge.java
@@ -17,6 +17,18 @@ public class Bridge {
     }
 
     /**
+     * Clears any data associated with the given target object that may be stored to disk. This
+     * will not affect data stored for restoration after configuration changes.
+     * <p>
+     * It is required to call {@link #initialize(Context, SavedStateHandler)} before calling this
+     * method.
+     */
+    public static void clear(@NonNull Object target) {
+        checkInitialization();
+        sDelegate.clear(target);
+    }
+
+    /**
      * Initializes the framework used to save and restore data and route it to a location free from
      * {@link android.os.TransactionTooLargeException}. The actual state saving and restoration
      * of each object will be performed by the provided {@link SavedStateHandler}.

--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -51,6 +51,15 @@ class BridgeDelegate {
         clearDataFromDisk(uuid);
     }
 
+    void clearAll() {
+        mRecentUuids.clear();
+        mUuidBundleMap.clear();
+        mObjectUuidMap.clear();
+        mSharedPreferences.edit()
+                .clear()
+                .apply();
+    }
+
     private void clearDataForUuid(@NonNull String uuid) {
         mRecentUuids.remove(uuid);
         mUuidBundleMap.remove(uuid);

--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -43,9 +43,21 @@ class BridgeDelegate {
         mSavedStateHandler = savedStateHandler;
     }
 
+    void clear(@NonNull Object target) {
+        String uuid = mObjectUuidMap.remove(target);
+        if (uuid == null) {
+            return;
+        }
+        clearDataFromDisk(uuid);
+    }
+
     private void clearDataForUuid(@NonNull String uuid) {
         mRecentUuids.remove(uuid);
         mUuidBundleMap.remove(uuid);
+        clearDataFromDisk(uuid);
+    }
+
+    private void clearDataFromDisk(@NonNull String uuid) {
         mSharedPreferences.edit()
                 .remove(getKeyForEncodedBundle(uuid))
                 .apply();

--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -110,7 +110,7 @@ class BridgeDelegate {
         return bundle;
     }
 
-    void restoreInstanceStateInternal(@NonNull Object target, @Nullable Bundle state) {
+    void restoreInstanceState(@NonNull Object target, @Nullable Bundle state) {
         boolean isFirstRestoreCall = mIsFirstRestoreCall;
         mIsFirstRestoreCall = false;
         if (state == null) {
@@ -139,7 +139,7 @@ class BridgeDelegate {
         clearDataForUuid(uuid);
     }
 
-    void saveInstanceStateInternal(@NonNull Object target, @NonNull Bundle state) {
+    void saveInstanceState(@NonNull Object target, @NonNull Bundle state) {
         String uuid = mObjectUuidMap.get(target);
         if (uuid == null) {
             uuid = UUID.randomUUID().toString();

--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -34,6 +34,13 @@ class BridgeDelegate {
         mSavedStateHandler = savedStateHandler;
     }
 
+    private void clearDataForUuid(@NonNull String uuid) {
+        mUuidBundleMap.remove(uuid);
+        mSharedPreferences.edit()
+                .remove(getKeyForEncodedBundle(uuid))
+                .apply();
+    }
+
     private String getKeyForEncodedBundle(@NonNull String uuid) {
         return String.format(KEY_BUNDLE, uuid);
     }
@@ -83,6 +90,7 @@ class BridgeDelegate {
         }
         WrapperUtils.unwrapOptimizedObjects(bundle);
         mSavedStateHandler.restoreInstanceState(target, bundle);
+        clearDataForUuid(uuid);
     }
 
     void saveInstanceStateInternal(@NonNull Object target, @NonNull Bundle state) {

--- a/bridge/src/main/java/com/livefront/bridge/NoOpSavedStateHandler.java
+++ b/bridge/src/main/java/com/livefront/bridge/NoOpSavedStateHandler.java
@@ -1,0 +1,19 @@
+package com.livefront.bridge;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+class NoOpSavedStateHandler implements SavedStateHandler {
+
+    @Override
+    public void saveInstanceState(@NonNull Object target, @NonNull Bundle state) {
+        // no-op
+    }
+
+    @Override
+    public void restoreInstanceState(@NonNull Object target, @Nullable Bundle state) {
+        // no-op
+    }
+
+}


### PR DESCRIPTION
This PR is focused on ensuring that data stored to disk is actively cleared when possible so that it doesn't accumulate too much before the next full clear event. Currently, all data stored to disk is cleared the first time Bridge detects the app is launched without saved state. There are now several new features to clear data more frequently:

- Data associated with a given object is now always automatically cleared when that data is restored to that object with `restoreInstanceState`.
- Anytime there is a `saveInstanceState` event, Bridge will do its best to see if any objects referenced weakly are no longer in use. When that is the case, Bridge will automatically clear the state for those objects. Because we cannot guarantee that unused objects get cleared up in a timely manner, this is just a "best effort" attempt at automatically clearing stale state.
- A new `Bridge.clear(Object)` method has been added. The intention for this method is that it may optionally be placed in the `onDestroy` method of a `Activity`, `Fragment`, etc. to ensure that any disk-related data will be cleared when that object is no longer needed. While not strictly required, use of this method will be recommended.
- A new `Bridge.clearAll(Context)` method has been added. The intention for this method is essentially to provide an easy way to migrate away from the use of Bridge while still ensuring that all data associated with it is properly cleared from disk.