### PR TITLE
Feature/hosted javadoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Bridge
 
+[![Release](https://jitpack.io/v/Livefront/bridge.svg)](https://jitpack.io/#Livefront/bridge)
+
 A library for avoiding TransactionTooLargeException during state saving and restoration.
+
 
 ## Contents
 
@@ -12,6 +15,7 @@ A library for avoiding TransactionTooLargeException during state saving and rest
 * [Limitations](#limitations)
 * [Testing](#testing)
 * [License](#license)
+* [Javadoc](https://jitpack.io/com/github/livefront/bridge/feature~hosted-javadoc-v1.1.0-g45d8d59-1/javadoc/index.html)
 
 <a name="motivation"></a>
 ## Motivation

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 A library for avoiding TransactionTooLargeException during state saving and restoration.
 
-
 ## Contents
 
 * [Motivation](#motivation)
@@ -15,7 +14,6 @@ A library for avoiding TransactionTooLargeException during state saving and rest
 * [Limitations](#limitations)
 * [Testing](#testing)
 * [License](#license)
-* [Javadoc](https://jitpack.io/com/github/livefront/bridge/feature~hosted-javadoc-v1.1.0-g45d8d59-1/javadoc/index.html)
 
 <a name="motivation"></a>
 ## Motivation

--- a/bridge/build.gradle
+++ b/bridge/build.gradle
@@ -20,3 +20,28 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:25.3.1'
 }
+
+
+// build a jar with source files
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+task javadoc(type: Javadoc) {
+    failOnError  false
+    source = android.sourceSets.main.java.sourceFiles
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    classpath += configurations.compile
+}
+
+// build a jar with javadoc
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}

--- a/bridge/build.gradle
+++ b/bridge/build.gradle
@@ -21,7 +21,6 @@ dependencies {
     compile 'com.android.support:appcompat-v7:25.3.1'
 }
 
-
 // build a jar with source files
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs


### PR DESCRIPTION
Noticed javadoc was not included with the source so I couldn't get documentation inside of Android Studio when using the lib. I just did a copy-pasta of what I found here: https://github.com/jitpack/android-example/blob/master/library/build.gradle  

Now, we have a fancy badge in the `README`, hosted javadoc (link will need to be updated each release), and jitpack now builds with javadoc so users can see it in IDE.

# Before
![screen shot 2017-08-16 at 4 23 11 pm](https://user-images.githubusercontent.com/2422090/29387262-d36c6090-82a4-11e7-9181-445ed33e5bd8.png)


# After
![screen shot 2017-08-16 at 5 03 13 pm](https://user-images.githubusercontent.com/2422090/29387268-da21cd9e-82a4-11e7-8d47-0a2948bef346.png)