### PR TITLE
Fix clear for fragment backstack

### DIFF
--- a/bridge/src/main/java/com/livefront/bridge/ActivityLifecycleCallbacksAdapter.java
+++ b/bridge/src/main/java/com/livefront/bridge/ActivityLifecycleCallbacksAdapter.java
@@ -1,0 +1,47 @@
+package com.livefront.bridge;
+
+import android.app.Activity;
+import android.app.Application.ActivityLifecycleCallbacks;
+import android.os.Build;
+import android.os.Bundle;
+import android.support.annotation.RequiresApi;
+
+@RequiresApi(api = Build.VERSION_CODES.ICE_CREAM_SANDWICH)
+abstract class ActivityLifecycleCallbacksAdapter implements ActivityLifecycleCallbacks {
+
+    @Override
+    public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+        // no-op
+    }
+
+    @Override
+    public void onActivityDestroyed(Activity activity) {
+        // no-op
+    }
+
+    @Override
+    public void onActivityPaused(Activity activity) {
+        // no-op
+    }
+
+    @Override
+    public void onActivityResumed(Activity activity) {
+        // no-op
+    }
+
+    @Override
+    public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+        // no-op
+    }
+
+    @Override
+    public void onActivityStarted(Activity activity) {
+        // no-op
+    }
+
+    @Override
+    public void onActivityStopped(Activity activity) {
+        // no-op
+    }
+
+}

--- a/bridge/src/main/java/com/livefront/bridge/Bridge.java
+++ b/bridge/src/main/java/com/livefront/bridge/Bridge.java
@@ -1,6 +1,7 @@
 package com.livefront.bridge;
 
 import android.content.Context;
+import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -18,7 +19,9 @@ public class Bridge {
 
     /**
      * Clears any data associated with the given target object that may be stored to disk. This
-     * will not affect data stored for restoration after configuration changes.
+     * will not affect data stored for restoration after configuration changes. Due to how these
+     * changes are monitored, this method will have no affect prior to
+     * {@link VERSION_CODES#ICE_CREAM_SANDWICH}.
      * <p>
      * It is required to call {@link #initialize(Context, SavedStateHandler)} before calling this
      * method.

--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -57,7 +57,7 @@ class BridgeDelegate {
         if (uuid == null) {
             return;
         }
-        clearDataFromDisk(uuid);
+        clearDataForUuid(uuid);
     }
 
     void clearAll() {

--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -1,7 +1,11 @@
 package com.livefront.bridge;
 
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.support.annotation.NonNull;
@@ -29,6 +33,7 @@ class BridgeDelegate {
      */
     private static final int AUTO_DATA_CLEAR_INTERVAL_MS = 100;
 
+    private boolean mIsClearAllowed = false;
     private boolean mIsFirstRestoreCall = true;
     private long mLastClearTime;
     private Map<String, Bundle> mUuidBundleMap = new HashMap<>();
@@ -41,9 +46,13 @@ class BridgeDelegate {
                    @NonNull SavedStateHandler savedStateHandler) {
         mSharedPreferences = context.getSharedPreferences(TAG, Context.MODE_PRIVATE);
         mSavedStateHandler = savedStateHandler;
+        registerForLifecycleEvents(context);
     }
 
     void clear(@NonNull Object target) {
+        if (!mIsClearAllowed) {
+            return;
+        }
         String uuid = mObjectUuidMap.remove(target);
         if (uuid == null) {
             return;
@@ -117,6 +126,30 @@ class BridgeDelegate {
         Bundle bundle = parcel.readBundle(BridgeDelegate.class.getClassLoader());
         parcel.recycle();
         return bundle;
+    }
+
+    @SuppressLint("NewApi")
+    private void registerForLifecycleEvents(@NonNull Context context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+            // Below this version we'll simply never allow clearing because we don't have a great
+            // hook for knowing when a config change is happening.
+            mIsClearAllowed = false;
+            return;
+        }
+        ((Application) context.getApplicationContext()).registerActivityLifecycleCallbacks(
+                new ActivityLifecycleCallbacksAdapter() {
+                    @Override
+                    public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+                        mIsClearAllowed = true;
+                    }
+
+                    @Override
+                    public void onActivityDestroyed(Activity activity) {
+                        // Don't allow clearing during known configuration changes
+                        mIsClearAllowed = !activity.isChangingConfigurations();
+                    }
+                }
+        );
     }
 
     void restoreInstanceState(@NonNull Object target, @Nullable Bundle state) {


### PR DESCRIPTION
This PR fixes an edge case when using the `clear` method during a configuration change. My original assumption was that during a config change, any `Activity` / `Fragment` having their `onDestroy` method called will soon be recreated and get a call to `onCreate`. For this reason, the original `clear` method always deleted data from disk but kept any data stored in memory for use when the config change was over. 

This assumption was correct in _most_ cases, but failed to account for cases when the current `Activity` has had at least one `FragmentTransaction` using `replace` and `addToBackStack`. In this case, any Fragment that has been removed as the result of the `replace` call but is in the backstack will receive an `onDestroy` call  but will _not_ immediately receive a call to `onCreate` when the `Activity` is recreated; that only happens when the `Fragment` is added back from the backstack.

To get around this issue, I'm now explicitly listening for configuration changes by registering a `ActivityLifecycleCallbacks` with the main application and blocking any calls to `clear` when a call to `onActivityDestroyed` passes an `Activity` that returns `activity.isChangingConfigurations()`. Because `ActivityLifecycleCallbacks` are only available for API 14+, I've chosen to make the `clear` method a no-op for lower versions rather than bump the min SDK for what is really just a minor bug fix.

I've also updated the `clear` method to remove _all_ data (disk and memory) when any clearing is allowed. This is because we no longer need to keep the data in memory around in case we want to restore after a config change since calling `clear` is a no-op in that scenario now anyway.