### PR TITLE
Prepare for v1.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 Change Log
 ==========
 
-Version 1.1.0 *(2017-08-04)*
+Version 1.1.1 *(2017-08-17)*
+----------------------------
+
+ * Fixed `clear` behavior for a removed `Fragment` in the backstack.
+
+Version 1.1.0 *(2017-08-16)*
 ----------------------------
 
  * Added support for saving Bitmaps.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A library for avoiding TransactionTooLargeException during state saving and rest
 * [Limitations](#limitations)
 * [Testing](#testing)
 * [License](#license)
+* [Javadoc](https://jitpack.io/com/github/livefront/bridge/v1.1.1/javadoc/index.html)
 
 <a name="motivation"></a>
 ## Motivation
@@ -90,7 +91,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.github.livefront:bridge:v1.1.0'
+    compile 'com.github.livefront:bridge:v1.1.1'
 }
 ```
 


### PR DESCRIPTION
Updates the `README` and `CHANGELOG` in anticipation of the v1.1.1 release. I've also corrected to date that v1.1.0 was released as reported by the `CHANGELOG`.