### PR TITLE
Do not automatically remove "stale" data when targets go out of memory

### DIFF
--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -15,9 +15,7 @@ import android.util.Base64;
 import com.livefront.bridge.wrapper.WrapperUtils;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.WeakHashMap;
 
@@ -28,18 +26,11 @@ class BridgeDelegate {
     private static final String KEY_BUNDLE = "bundle_%s";
     private static final String KEY_UUID = "uuid_%s";
 
-    /**
-     * Time (in milliseconds) to wait between attempts to automatically clear stale data.
-     */
-    private static final int AUTO_DATA_CLEAR_INTERVAL_MS = 100;
-
     private boolean mIsClearAllowed = false;
     private boolean mIsFirstRestoreCall = true;
-    private long mLastClearTime;
     private Map<String, Bundle> mUuidBundleMap = new HashMap<>();
     private Map<Object, String> mObjectUuidMap = new WeakHashMap<>();
     private SavedStateHandler mSavedStateHandler;
-    private Set<String> mRecentUuids = new HashSet<>();
     private SharedPreferences mSharedPreferences;
 
     BridgeDelegate(@NonNull Context context,
@@ -61,7 +52,6 @@ class BridgeDelegate {
     }
 
     void clearAll() {
-        mRecentUuids.clear();
         mUuidBundleMap.clear();
         mObjectUuidMap.clear();
         mSharedPreferences.edit()
@@ -70,7 +60,6 @@ class BridgeDelegate {
     }
 
     private void clearDataForUuid(@NonNull String uuid) {
-        mRecentUuids.remove(uuid);
         mUuidBundleMap.remove(uuid);
         clearDataFromDisk(uuid);
     }
@@ -79,30 +68,6 @@ class BridgeDelegate {
         mSharedPreferences.edit()
                 .remove(getKeyForEncodedBundle(uuid))
                 .apply();
-    }
-
-    /**
-     * Attempts to clear data associated with references held weakly that have been cleared. Note
-     * that there is no guarantee of success, as some references may still be held by the system
-     * longer than is actually necessary.
-     */
-    private void clearStaleData() {
-        long currentTime = System.currentTimeMillis();
-        if (currentTime - mLastClearTime < AUTO_DATA_CLEAR_INTERVAL_MS) {
-            // Avoid too many checks during the same stop event
-            return;
-        }
-        mLastClearTime = currentTime;
-        System.gc();
-
-        // Remove all the remaining UUIDs in the object map from the recent UUID list. Anything
-        // left represents objects that were garbage collected, so we should clear up any saved
-        // state associated with them.
-        Set<String> staleUuids = new HashSet<>(mRecentUuids);
-        staleUuids.removeAll(mObjectUuidMap.values());
-        for (String uuid : staleUuids) {
-            clearDataForUuid(uuid);
-        }
     }
 
     private String getKeyForEncodedBundle(@NonNull String uuid) {
@@ -195,10 +160,8 @@ class BridgeDelegate {
             return;
         }
         WrapperUtils.wrapOptimizedObjects(bundle);
-        mRecentUuids.add(uuid);
         mUuidBundleMap.put(uuid, bundle);
         writeToDisk(uuid, bundle);
-        clearStaleData();
     }
 
     private void writeToDisk(@NonNull String uuid,


### PR DESCRIPTION
This PR removes the automatic clearing of "stale" data whenever `Bridge.saveInstanceState` is called. This served as a helpful way to remove unneeded data without actually requiring use of the `Bridge.clear` method but it turns out there are scenarios where a `Fragment` may go out of memory but the saved state data might still need to be used again later (see https://github.com/livefront/bridge/issues/11 and https://github.com/livefront/bridge/issues/13).

This PR essentially just reverts the commit that introduced this behavior (https://github.com/livefront/bridge/pull/5/commits/fdcedd1db36559ec6a0c6692b0f901de863d0317). Rather than relying on the automatic clearing, library users can still just use the `Bridge.clear` method if they are concerned about cleaning up stale data before the next app launch.