### PR TITLE
Prepare for v1.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+Version 1.1.2 *(2018-06-04)*
+----------------------------
+
+ * Data will no longer be automatically cleared for objects that go out of memory while an app is running. It is now more strongly recommended to use the `clear` method to manually delete data for objects in the process of being discarded.
+
 Version 1.1.1 *(2017-08-17)*
 ----------------------------
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ That's it! You don't have to change any of your other code. If you are using any
 <a name="clear"></a>
 ## Clearing Data
 
-Bridge will clear all data written to disk each time the app is loaded and it detects that there is no saved state the system is trying to restore. It will also try to automatically clear state while the app is actively used to avoid holding onto data that is no longer relevant. However, in order to guarantee that no data is retained on disk for screens that have been left, the `Bridge.clear()` method may be used:
+Bridge will clear all data written to disk each time the app is loaded and it detects that there is no saved state the system is trying to restore. It is recommended, however, to also manually clear data for objects that will no longer be needed, such as an `Activity` the user has finished. For this purpose, the `Bridge.clear()` method may be used:
 
 ```java
     @Override
@@ -77,6 +77,8 @@ Bridge will clear all data written to disk each time the app is loaded and it de
         Bridge.clear(this);
     }
 ```
+
+This method is typically safe to call without any additional logic, as it will only clear data when the current `Activity` is not undergoing a configuration change. Note that in some unique cases (such as when using a `FragmentStatePagerAdapter`) the OS will "destroy" a `Fragment` but retain its saved state `Bundle` in case it needs to reconstruct that `Fragment` from scratch later. In these cases calls to `Bridge.clear()` should be omitted.
 
 In the event that you might like to migrate away from the use of `Bridge` but ensure that all associated data is cleared, `Bridge.clearAll` may be called at any time.
 
@@ -91,7 +93,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.github.livefront:bridge:v1.1.1'
+    compile 'com.github.livefront:bridge:v1.1.2'
 }
 ```
 


### PR DESCRIPTION
This PR updates the README and CHANGELOG in anticipation of the v1.1.2 release, which will include the changes from https://github.com/livefront/bridge/pull/15. I've also added a clarifying remark about scenarios where `Bridge.clear()` should _not_ be used. For some future work I'm going to come up with a way to "tag" objects so they can be cleared later but for now the best I can say is to skip using the method in some cases.