### PR TITLE
Ignore clearing when an Activity is destroyed but not finishing

### DIFF
--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -110,8 +110,9 @@ class BridgeDelegate {
 
                     @Override
                     public void onActivityDestroyed(Activity activity) {
-                        // Don't allow clearing during known configuration changes
-                        mIsClearAllowed = !activity.isChangingConfigurations();
+                        // Don't allow clearing during known configuration changes (and other
+                        // events unrelated to calling "finish()".)
+                        mIsClearAllowed = activity.isFinishing();
                     }
                 }
         );


### PR DESCRIPTION
This PR improves the safety checks when the `clear` method is called to address issues discussed in https://github.com/livefront/bridge/issues/21. Currently all calls to `clear` are ignored when the most recent `Activity.onDestroy` call detects that `Activity` is going through a configuration change. This check has been updated to be even more explicit : when an `Activity` is being destroyed, clearing is only allowed when that `Activity` is _finishing_. The excludes configuration changes as before but also excludes some other weird cases. For example, when "Don't Keep Activities" is enabled, leaving an `Activity` calls `onDestroy` even though it isn't finishing and will be recreated. Also, the [documentation for `Activity.onDestroy`](https://developer.android.com/reference/android/app/Activity.html#onDestroy()) suggests the OS might call `onDestroy` when killing a process:

>  This can happen either because the activity is finishing (someone called finish() on it, or because the system is temporarily destroying this instance of the activity to save space. You can distinguish between these two scenarios with the isFinishing() method.

I've never actually _seen_ this happen before, but this new check will also exclude that case as well (should it arise).