### PR TITLE
Make initial launch clearing safer

### DIFF
--- a/bridge/build.gradle
+++ b/bridge/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 25
     buildToolsVersion "25.0.2"
     defaultConfig {
-        minSdkVersion 12
+        minSdkVersion 14
         targetSdkVersion 25
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }

--- a/bridge/src/main/java/com/livefront/bridge/ActivityLifecycleCallbacksAdapter.java
+++ b/bridge/src/main/java/com/livefront/bridge/ActivityLifecycleCallbacksAdapter.java
@@ -6,7 +6,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.RequiresApi;
 
-@RequiresApi(api = Build.VERSION_CODES.ICE_CREAM_SANDWICH)
 abstract class ActivityLifecycleCallbacksAdapter implements ActivityLifecycleCallbacks {
 
     @Override

--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -5,7 +5,6 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.support.annotation.NonNull;
@@ -95,12 +94,6 @@ class BridgeDelegate {
 
     @SuppressLint("NewApi")
     private void registerForLifecycleEvents(@NonNull Context context) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-            // Below this version we'll simply never allow clearing because we don't have a great
-            // hook for knowing when a config change is happening.
-            mIsClearAllowed = false;
-            return;
-        }
         ((Application) context.getApplicationContext()).registerActivityLifecycleCallbacks(
                 new ActivityLifecycleCallbacksAdapter() {
                     @Override


### PR DESCRIPTION
This PR updates the logic used to decide when to clear all saved data on a "fresh" launch to address issues discussed in https://github.com/livefront/bridge/issues/22. The existing logic assumed that `Bridge.saveInstanceState` / `Bridge.restoreInstanceState` would be used on _all Activities_ in an app by placing those calls in a base class. A failure to do so could result in data being cleared at the wrong time. Since that is neither discussed in the README nor technically enforceable anyway, I've decided to remove that assumption.

The updates made here take advantage of the `ActivityLifecycleCallbacks` already being used to hook into `Activity.onCreate` events. I've simply shifted the existing logic from `restoreInstanceState` to the `onActivityCreated` callback of the `ActivityLifecycleCallbacks`. In order for this to work in all cases, however, I've needed to bump the min SDK from 12 to 14 to ensure that all users of `Bridge` get the same behavior. I highly doubt anyone was using this for < 14 so I don't see this as much of a problem.