### PR TITLE
Prepare for v1.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+Version 1.1.3 *(2018-10-08)*
+----------------------------
+ * `Bridge.clear` is now safe to call in `Activity.onDestroy` when "Don't Keep Activities" is enabled.
+ * All data is now correctly cleared on fresh launches for apps that do not use `Bridge` in every `Activity`.
+ * Min SDK is now 14.
+
 Version 1.1.2 *(2018-06-04)*
 ----------------------------
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Bridge.initialize(getApplicationContext(), new SavedStateHandler() {
 
 That's it! You don't have to change any of your other code. If you are using any other `Icepick`-like library, simply swap out the library referred to in the `SavedStateHandler`.
 
+Note that if you use the [Android-State](https://github.com/evernote/android-state) library as your `SavedStateHandler`, do **not** use the global settings by calling `StateSaver.setEnabledForAllActivitiesAndSupportFragments(this, true)`; failure to omit this will defeat the purpose of using `Bridge` and you will still see `TransactionTooLargeException` in your application.
+
 <a name="clear"></a>
 ## Clearing Data
 
@@ -93,7 +95,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.github.livefront:bridge:v1.1.2'
+    compile 'com.github.livefront:bridge:v1.1.3'
 }
 ```
 


### PR DESCRIPTION
This PR updates the README and CHANGELOG in anticipation of the v1.1.3 release, which will include the fixes from https://github.com/livefront/bridge/pull/23 and https://github.com/livefront/bridge/pull/24. I've also added a note to the README to address the discussion in https://github.com/livefront/bridge/issues/18.