### PR TITLE
Performance improvements

### DIFF
--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -25,6 +25,7 @@ class BridgeDelegate {
     private static final String KEY_BUNDLE = "bundle_%s";
     private static final String KEY_UUID = "uuid_%s";
 
+    private int mActivityCount = 0;
     private boolean mIsClearAllowed = false;
     private boolean mIsConfigChange = false;
     private boolean mIsFirstCreateCall = true;
@@ -76,6 +77,10 @@ class BridgeDelegate {
 
     private String getKeyForUuid(@NonNull Object target) {
         return String.format(KEY_UUID, target.getClass().getName());
+    }
+
+    private boolean isAppInForeground() {
+        return mActivityCount > 0;
     }
 
     @Nullable
@@ -131,6 +136,16 @@ class BridgeDelegate {
                         // processing the Bundle and writing it to disk on a background thread)
                         // during this period.
                         mIsConfigChange = activity.isChangingConfigurations();
+                    }
+
+                    @Override
+                    public void onActivityStarted(Activity activity) {
+                        mActivityCount++;
+                    }
+
+                    @Override
+                    public void onActivityStopped(Activity activity) {
+                        mActivityCount--;
                     }
                 }
         );


### PR DESCRIPTION
This PR adds a couple of performance improvements:

1. Processing the `Bundle` / `Parcel` and writing to disk is now completely skipped during configuration changes. This was always a bit unnecessary because it is still in memory and used immediately after the config change.
2. Processing the `Bundle` / `Parcel` (i.e. writing to a `Parcel` and calling `parcel.marshall()`) is now done on a background thread when the app is in the foreground. I'm doing this because the `parcel.marshall()` call itself can take some time when the `Bundle` gets to be quite large. (Note that writing the resulting data to disk was always done on a background thread). I'm only doing this when the app is in the foreground because when it is going into the background we actually want the main thread to wait until all the data is saved. If we don't, its possible for the OS to kill the process before the background tasks complete, because as soon as the app is in the "stopped" state it is killable.