### PR TITLE
Add reusable sample app custom view

### DIFF
--- a/bridgesample/src/main/java/com/livefront/bridgesample/base/BridgeBaseActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/base/BridgeBaseActivity.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import com.livefront.bridge.Bridge
 
-abstract class BaseActivity : AppCompatActivity() {
+abstract class BridgeBaseActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         Bridge.restoreInstanceState(this, savedInstanceState)

--- a/bridgesample/src/main/java/com/livefront/bridgesample/common/view/BitmapGeneratorView.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/common/view/BitmapGeneratorView.kt
@@ -1,0 +1,60 @@
+package com.livefront.bridgesample.common.view
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.support.annotation.StringRes
+import android.util.AttributeSet
+import android.widget.RelativeLayout
+import com.livefront.bridgesample.R
+import com.livefront.bridgesample.util.generateNoisyStripedBitmap
+import kotlinx.android.synthetic.main.view_bitmap_generator_content.view.generateDataButton
+import kotlinx.android.synthetic.main.view_bitmap_generator_content.view.headerText
+import kotlinx.android.synthetic.main.view_bitmap_generator_content.view.imageView
+import kotlinx.android.synthetic.main.view_bitmap_generator_content.view.navigateButton
+import kotlinx.android.synthetic.main.view_bitmap_generator_content.view.statusText
+
+/**
+ * A view that generates a [Bitmap] when clicking on a button. This `Bitmap` can then be retrieved
+ * as the [generatedBitmap] in order to test saving / restoring it. The
+ * [onNavigateButtonClickListener] may be set to provide some action when the corresponding button
+ * is clicked.
+ */
+class BitmapGeneratorView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+    defStyleRes: Int = 0
+) : RelativeLayout(context, attrs, defStyleAttr, defStyleRes) {
+    var generatedBitmap: Bitmap? = null
+        /**
+         * Sets the [Bitmap] to display in this view. This will be considered as "restored" from a
+         * saved state.
+         */
+        set(value) {
+            field = value
+            value?.let {
+                imageView.setImageBitmap(it)
+                statusText.setText(R.string.restored_from_saved_state)
+            }
+        }
+
+    var onNavigateButtonClickListener: (() -> Unit)? = null
+
+    init {
+        inflate(context, R.layout.view_bitmap_generator_content, this)
+        navigateButton.setOnClickListener { onNavigateButtonClickListener?.invoke() }
+        generateDataButton.setOnClickListener {
+            generateDataButton.isEnabled = false
+            generateNoisyStripedBitmap { bitmap ->
+                generatedBitmap = bitmap
+                generateDataButton.isEnabled = true
+                imageView.setImageBitmap(bitmap)
+                statusText.setText(R.string.image_generated)
+            }
+        }
+    }
+
+    fun setHeaderText(@StringRes textRes: Int) {
+        headerText.setText(textRes)
+    }
+}

--- a/bridgesample/src/main/java/com/livefront/bridgesample/main/activity/MainActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/main/activity/MainActivity.kt
@@ -2,13 +2,13 @@ package com.livefront.bridgesample.main.activity
 
 import android.os.Bundle
 import com.livefront.bridgesample.R
-import com.livefront.bridgesample.base.BaseActivity
+import com.livefront.bridgesample.base.BridgeBaseActivity
 import com.livefront.bridgesample.main.adapter.MainAdapter
 import com.livefront.bridgesample.main.model.getScenarios
 import kotlinx.android.synthetic.main.activity_main.recyclerView
 import kotlinx.android.synthetic.main.activity_main.toolbar
 
-class MainActivity : BaseActivity() {
+class MainActivity : BridgeBaseActivity() {
     private lateinit var mainAdapter: MainAdapter
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/LargeDataActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/LargeDataActivity.kt
@@ -8,6 +8,7 @@ import com.evernote.android.state.State
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.base.BaseActivity
 import com.livefront.bridgesample.util.generateNoisyStripedBitmap
+import com.livefront.bridgesample.util.handleHomeAsBack
 import kotlinx.android.synthetic.main.activity_large_data.generateDataButton
 import kotlinx.android.synthetic.main.activity_large_data.headerText
 import kotlinx.android.synthetic.main.activity_large_data.imageView
@@ -54,13 +55,7 @@ class LargeDataActivity : BaseActivity() {
         }
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            android.R.id.home -> {
-                onBackPressed()
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
-        }
+    override fun onOptionsItemSelected(item: MenuItem) = handleHomeAsBack(item) {
+        super.onOptionsItemSelected(item)
     }
 }

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/LargeDataActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/LargeDataActivity.kt
@@ -6,13 +6,13 @@ import android.os.Bundle
 import android.view.MenuItem
 import com.evernote.android.state.State
 import com.livefront.bridgesample.R
-import com.livefront.bridgesample.base.BaseActivity
+import com.livefront.bridgesample.base.BridgeBaseActivity
 import com.livefront.bridgesample.util.handleHomeAsBack
 import com.livefront.bridgesample.util.setHomeAsUpToolbar
 import kotlinx.android.synthetic.main.activity_large_data.bitmapGeneratorView
 import kotlinx.android.synthetic.main.basic_toolbar.toolbar
 
-class LargeDataActivity : BaseActivity() {
+class LargeDataActivity : BridgeBaseActivity() {
     @State
     var savedBitmap: Bitmap? = null
 

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/LargeDataActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/LargeDataActivity.kt
@@ -9,6 +9,7 @@ import com.livefront.bridgesample.R
 import com.livefront.bridgesample.base.BaseActivity
 import com.livefront.bridgesample.util.generateNoisyStripedBitmap
 import com.livefront.bridgesample.util.handleHomeAsBack
+import com.livefront.bridgesample.util.setHomeAsUpToolbar
 import kotlinx.android.synthetic.main.activity_large_data.generateDataButton
 import kotlinx.android.synthetic.main.activity_large_data.headerText
 import kotlinx.android.synthetic.main.activity_large_data.imageView
@@ -23,12 +24,7 @@ class LargeDataActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_large_data)
-        setSupportActionBar(toolbar)
-        supportActionBar!!.apply {
-            setDisplayHomeAsUpEnabled(true)
-            setHomeButtonEnabled(true)
-            setTitle(R.string.large_data_screen_title)
-        }
+        setHomeAsUpToolbar(toolbar, R.string.large_data_screen_title)
 
         headerText.setText(R.string.large_data_header)
 

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/LargeDataActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/LargeDataActivity.kt
@@ -7,51 +7,35 @@ import android.view.MenuItem
 import com.evernote.android.state.State
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.base.BaseActivity
-import com.livefront.bridgesample.util.generateNoisyStripedBitmap
 import com.livefront.bridgesample.util.handleHomeAsBack
 import com.livefront.bridgesample.util.setHomeAsUpToolbar
-import kotlinx.android.synthetic.main.activity_large_data.generateDataButton
-import kotlinx.android.synthetic.main.activity_large_data.headerText
-import kotlinx.android.synthetic.main.activity_large_data.imageView
-import kotlinx.android.synthetic.main.activity_large_data.navigateButton
-import kotlinx.android.synthetic.main.activity_large_data.statusText
+import kotlinx.android.synthetic.main.activity_large_data.bitmapGeneratorView
 import kotlinx.android.synthetic.main.basic_toolbar.toolbar
 
 class LargeDataActivity : BaseActivity() {
     @State
-    lateinit var bitmap: Bitmap
+    var savedBitmap: Bitmap? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_large_data)
         setHomeAsUpToolbar(toolbar, R.string.large_data_screen_title)
 
-        headerText.setText(R.string.large_data_header)
-
-        if (this::bitmap.isInitialized) {
-            // The Bitmap is restored from a saved state. We can just show it directly.
-            imageView.setImageBitmap(bitmap)
-            statusText.setText(R.string.restored_from_saved_state)
-        }
-
-        generateDataButton.setOnClickListener {
-            // Generate a large Bitmap, save it to the "bitmap" variable, and then show it in the
-            // view. In general, it is not technically a great idea to manage Bitmaps this way;
-            // this is only meant as a visual indication of "a large amount of data".
-            generateDataButton.isEnabled = false
-            generateNoisyStripedBitmap { generatedBitmap ->
-                bitmap = generatedBitmap
-                generateDataButton.isEnabled = true
-                imageView.setImageBitmap(generatedBitmap)
-                statusText.setText(R.string.image_generated)
+        bitmapGeneratorView.apply {
+            setHeaderText(R.string.large_data_header)
+            generatedBitmap = savedBitmap
+            onNavigateButtonClickListener = {
+                startActivity(Intent(this@LargeDataActivity, SuccessActivity::class.java))
             }
-        }
-        navigateButton.setOnClickListener {
-            startActivity(Intent(this@LargeDataActivity, SuccessActivity::class.java))
         }
     }
 
     override fun onOptionsItemSelected(item: MenuItem) = handleHomeAsBack(item) {
         super.onOptionsItemSelected(item)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        savedBitmap = bitmapGeneratorView.generatedBitmap
+        super.onSaveInstanceState(outState)
     }
 }

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/NonBridgeLargeDataActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/NonBridgeLargeDataActivity.kt
@@ -8,6 +8,7 @@ import com.evernote.android.state.State
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.base.NonBridgeBaseActivity
 import com.livefront.bridgesample.util.generateNoisyStripedBitmap
+import com.livefront.bridgesample.util.handleHomeAsBack
 import kotlinx.android.synthetic.main.activity_large_data.generateDataButton
 import kotlinx.android.synthetic.main.activity_large_data.headerText
 import kotlinx.android.synthetic.main.activity_large_data.imageView
@@ -54,13 +55,7 @@ class NonBridgeLargeDataActivity : NonBridgeBaseActivity() {
         }
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            android.R.id.home -> {
-                onBackPressed()
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
-        }
+    override fun onOptionsItemSelected(item: MenuItem) = handleHomeAsBack(item) {
+        super.onOptionsItemSelected(item)
     }
 }

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/NonBridgeLargeDataActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/NonBridgeLargeDataActivity.kt
@@ -9,6 +9,7 @@ import com.livefront.bridgesample.R
 import com.livefront.bridgesample.base.NonBridgeBaseActivity
 import com.livefront.bridgesample.util.generateNoisyStripedBitmap
 import com.livefront.bridgesample.util.handleHomeAsBack
+import com.livefront.bridgesample.util.setHomeAsUpToolbar
 import kotlinx.android.synthetic.main.activity_large_data.generateDataButton
 import kotlinx.android.synthetic.main.activity_large_data.headerText
 import kotlinx.android.synthetic.main.activity_large_data.imageView
@@ -23,12 +24,7 @@ class NonBridgeLargeDataActivity : NonBridgeBaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_large_data)
-        setSupportActionBar(toolbar)
-        supportActionBar!!.apply {
-            setDisplayHomeAsUpEnabled(true)
-            setHomeButtonEnabled(true)
-            setTitle(R.string.non_bridge_large_data_screen_title)
-        }
+        setHomeAsUpToolbar(toolbar, R.string.non_bridge_large_data_screen_title)
 
         headerText.setText(R.string.non_bridge_large_data_header)
 

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/NonBridgeLargeDataActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/NonBridgeLargeDataActivity.kt
@@ -7,51 +7,35 @@ import android.view.MenuItem
 import com.evernote.android.state.State
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.base.NonBridgeBaseActivity
-import com.livefront.bridgesample.util.generateNoisyStripedBitmap
 import com.livefront.bridgesample.util.handleHomeAsBack
 import com.livefront.bridgesample.util.setHomeAsUpToolbar
-import kotlinx.android.synthetic.main.activity_large_data.generateDataButton
-import kotlinx.android.synthetic.main.activity_large_data.headerText
-import kotlinx.android.synthetic.main.activity_large_data.imageView
-import kotlinx.android.synthetic.main.activity_large_data.navigateButton
-import kotlinx.android.synthetic.main.activity_large_data.statusText
+import kotlinx.android.synthetic.main.activity_large_data.bitmapGeneratorView
 import kotlinx.android.synthetic.main.basic_toolbar.toolbar
 
 class NonBridgeLargeDataActivity : NonBridgeBaseActivity() {
     @State
-    lateinit var bitmap: Bitmap
+    var savedBitmap: Bitmap? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_large_data)
         setHomeAsUpToolbar(toolbar, R.string.non_bridge_large_data_screen_title)
 
-        headerText.setText(R.string.non_bridge_large_data_header)
-
-        if (this::bitmap.isInitialized) {
-            // The Bitmap is restored from a saved state. We can just show it directly.
-            imageView.setImageBitmap(bitmap)
-            statusText.setText(R.string.restored_from_saved_state)
-        }
-
-        generateDataButton.setOnClickListener {
-            // Generate a large Bitmap, save it to the "bitmap" variable, and then show it in the
-            // view. In general, it is not technically a great idea to manage Bitmaps this way;
-            // this is only meant as a visual indication of "a large amount of data".
-            generateDataButton.isEnabled = false
-            generateNoisyStripedBitmap { generatedBitmap ->
-                bitmap = generatedBitmap
-                generateDataButton.isEnabled = true
-                imageView.setImageBitmap(generatedBitmap)
-                statusText.setText(R.string.image_generated)
+        bitmapGeneratorView.apply {
+            setHeaderText(R.string.non_bridge_large_data_header)
+            generatedBitmap = savedBitmap
+            onNavigateButtonClickListener = {
+                startActivity(Intent(this@NonBridgeLargeDataActivity, SuccessActivity::class.java))
             }
-        }
-        navigateButton.setOnClickListener {
-            startActivity(Intent(this@NonBridgeLargeDataActivity, SuccessActivity::class.java))
         }
     }
 
     override fun onOptionsItemSelected(item: MenuItem) = handleHomeAsBack(item) {
         super.onOptionsItemSelected(item)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        savedBitmap = bitmapGeneratorView.generatedBitmap
+        super.onSaveInstanceState(outState)
     }
 }

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/SuccessActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/SuccessActivity.kt
@@ -2,9 +2,9 @@ package com.livefront.bridgesample.scenario.activity
 
 import android.os.Bundle
 import com.livefront.bridgesample.R
-import com.livefront.bridgesample.base.BaseActivity
+import com.livefront.bridgesample.base.BridgeBaseActivity
 
-class SuccessActivity : BaseActivity() {
+class SuccessActivity : BridgeBaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_success)

--- a/bridgesample/src/main/java/com/livefront/bridgesample/util/Activity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/util/Activity.kt
@@ -1,6 +1,9 @@
 package com.livefront.bridgesample.util
 
 import android.app.Activity
+import android.support.annotation.StringRes
+import android.support.v7.app.AppCompatActivity
+import android.support.v7.widget.Toolbar
 import android.view.MenuItem
 
 /**
@@ -17,4 +20,20 @@ fun Activity.handleHomeAsBack(
         true
     }
     else -> default(item)
+}
+
+/**
+ * Sets the given [Toolbar] with the given [titleRes] as an Action bar in the standard "home as up"
+ * configuration.
+ */
+fun AppCompatActivity.setHomeAsUpToolbar(
+    toolbar: Toolbar,
+    @StringRes titleRes: Int
+) {
+    setSupportActionBar(toolbar)
+    supportActionBar!!.apply {
+        setDisplayHomeAsUpEnabled(true)
+        setHomeButtonEnabled(true)
+        setTitle(titleRes)
+    }
 }

--- a/bridgesample/src/main/java/com/livefront/bridgesample/util/Activity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/util/Activity.kt
@@ -1,0 +1,20 @@
+package com.livefront.bridgesample.util
+
+import android.app.Activity
+import android.view.MenuItem
+
+/**
+ * Helper method for handling the standard "home as back press" behavior in
+ * [Activity.onOptionsItemSelected]. The [default] is a function that will be called when the item
+ * does not correspond to the "home" / "up" button.
+ */
+fun Activity.handleHomeAsBack(
+    item: MenuItem,
+    default: (MenuItem) -> Boolean
+): Boolean = when (item.itemId) {
+    android.R.id.home -> {
+        onBackPressed()
+        true
+    }
+    else -> default(item)
+}

--- a/bridgesample/src/main/res/layout/activity_large_data.xml
+++ b/bridgesample/src/main/res/layout/activity_large_data.xml
@@ -14,65 +14,11 @@
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true" />
 
-    <ScrollView
+    <com.livefront.bridgesample.common.view.BitmapGeneratorView
+        android:id="@+id/bitmapGeneratorView"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_above="@+id/generateDataButton"
+        android:layout_height="match_parent"
         android:layout_below="@id/toolbar"
-        android:fillViewport="true">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:orientation="vertical">
-
-            <TextView
-                android:id="@+id/headerText"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_margin="@dimen/default_margin"
-                android:gravity="center"
-                android:textSize="@dimen/header_text_size" />
-
-            <ImageView
-                android:id="@+id/imageView"
-                android:layout_width="@dimen/test_image_size"
-                android:layout_height="@dimen/test_image_size"
-                android:layout_gravity="center"
-                android:contentDescription="@null" />
-
-            <TextView
-                android:id="@+id/statusText"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_margin="@dimen/default_margin"
-                android:textSize="@dimen/default_text_size" />
-
-        </LinearLayout>
-
-    </ScrollView>
-
-    <Button
-        android:id="@id/generateDataButton"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_above="@+id/navigateButton"
-        android:layout_margin="@dimen/default_margin"
-        android:minHeight="@dimen/min_button_height"
-        android:text="@string/generate_data" />
-
-    <Button
-        android:id="@id/navigateButton"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:layout_marginStart="@dimen/default_margin"
-        android:layout_marginEnd="@dimen/default_margin"
-        android:layout_marginBottom="@dimen/default_margin"
-        android:minHeight="@dimen/min_button_height"
-        android:text="@string/navigate" />
+        android:layout_alignParentBottom="true" />
 
 </RelativeLayout>

--- a/bridgesample/src/main/res/layout/view_bitmap_generator_content.xml
+++ b/bridgesample/src/main/res/layout/view_bitmap_generator_content.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:parentTag="android.widget.RelativeLayout">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/generateDataButton"
+        android:layout_alignParentTop="true"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/headerText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_margin="@dimen/default_margin"
+                android:gravity="center"
+                android:textSize="@dimen/header_text_size" />
+
+            <ImageView
+                android:id="@+id/imageView"
+                android:layout_width="@dimen/test_image_size"
+                android:layout_height="@dimen/test_image_size"
+                android:layout_gravity="center"
+                android:contentDescription="@null" />
+
+            <TextView
+                android:id="@+id/statusText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_margin="@dimen/default_margin"
+                android:textSize="@dimen/default_text_size" />
+
+        </LinearLayout>
+
+    </ScrollView>
+
+    <Button
+        android:id="@id/generateDataButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/navigateButton"
+        android:layout_margin="@dimen/default_margin"
+        android:minHeight="@dimen/min_button_height"
+        android:text="@string/generate_data" />
+
+    <Button
+        android:id="@id/navigateButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_marginStart="@dimen/default_margin"
+        android:layout_marginEnd="@dimen/default_margin"
+        android:layout_marginBottom="@dimen/default_margin"
+        android:minHeight="@dimen/min_button_height"
+        android:text="@string/navigate" />
+
+</merge>


### PR DESCRIPTION
This PR is an effort to cut down on the copy-paste code used in the sample app in order to facilitate the addition of new "scenarios".  

- I've added a couple of helper methods to cut down on the boilerplate of adding new Activities and managing the `Toolbar`.
- I've created a reusable `BitmapGeneratorView` that can be used in Activities, Fragments, etc.
- I've renamed `BaseActivity` to `BridgeBaseActivity` to better contrast with `NonBridgeBaseActivity` and make it more clear what that base class does.