### PR TITLE
Add fragment scenarios

### DIFF
--- a/bridgesample/build.gradle
+++ b/bridgesample/build.gradle
@@ -41,5 +41,6 @@ dependencies {
 
     // Support Library
     implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
+    implementation "com.android.support:design:$supportLibraryVersion"
     implementation "com.android.support:recyclerview-v7:$supportLibraryVersion"
 }

--- a/bridgesample/src/main/AndroidManifest.xml
+++ b/bridgesample/src/main/AndroidManifest.xml
@@ -26,6 +26,8 @@
 
         <activity android:name=".main.activity.MainActivity" />
 
+        <activity android:name=".scenario.activity.FragmentContainerActivity" />
+
         <activity android:name=".scenario.activity.LargeDataActivity" />
 
         <activity android:name=".scenario.activity.NonBridgeLargeDataActivity" />

--- a/bridgesample/src/main/java/com/livefront/bridgesample/base/BridgeBaseFragment.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/base/BridgeBaseFragment.kt
@@ -2,9 +2,17 @@ package com.livefront.bridgesample.base
 
 import android.os.Bundle
 import android.support.v4.app.Fragment
+import android.support.v4.app.FragmentStatePagerAdapter
 import com.livefront.bridge.Bridge
 
 abstract class BridgeBaseFragment : Fragment() {
+    /**
+     * Determines whether or not [Bridge.clear] will be called in [onDestroy]. This is enabled by
+     * default but may be disabled in scenarios where Fragments are "recycled" (such as when using
+     * a [FragmentStatePagerAdapter].
+     */
+    open val shouldClearOnDestroy: Boolean = true
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         Bridge.restoreInstanceState(this, savedInstanceState)
@@ -17,6 +25,6 @@ abstract class BridgeBaseFragment : Fragment() {
 
     override fun onDestroy() {
         super.onDestroy()
-        Bridge.clear(this)
+        if (shouldClearOnDestroy) Bridge.clear(this)
     }
 }

--- a/bridgesample/src/main/java/com/livefront/bridgesample/base/BridgeBaseFragment.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/base/BridgeBaseFragment.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import android.support.v4.app.Fragment
 import com.livefront.bridge.Bridge
 
-abstract class BaseFragment : Fragment() {
+abstract class BridgeBaseFragment : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         Bridge.restoreInstanceState(this, savedInstanceState)

--- a/bridgesample/src/main/java/com/livefront/bridgesample/base/NonBridgeBaseFragment.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/base/NonBridgeBaseFragment.kt
@@ -1,0 +1,17 @@
+package com.livefront.bridgesample.base
+
+import android.os.Bundle
+import android.support.v4.app.Fragment
+import com.evernote.android.state.StateSaver
+
+open class NonBridgeBaseFragment : Fragment() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        StateSaver.restoreInstanceState(this, savedInstanceState)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        StateSaver.saveInstanceState(this, outState)
+    }
+}

--- a/bridgesample/src/main/java/com/livefront/bridgesample/common/view/BitmapGeneratorView.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/common/view/BitmapGeneratorView.kt
@@ -38,6 +38,7 @@ class BitmapGeneratorView @JvmOverloads constructor(
             }
         }
 
+    var onBitmapGeneratedListener: ((Bitmap) -> Unit)? = null
     var onNavigateButtonClickListener: (() -> Unit)? = null
 
     init {
@@ -50,6 +51,7 @@ class BitmapGeneratorView @JvmOverloads constructor(
                 generateDataButton.isEnabled = true
                 imageView.setImageBitmap(bitmap)
                 statusText.setText(R.string.image_generated)
+                onBitmapGeneratedListener?.invoke(bitmap)
             }
         }
     }

--- a/bridgesample/src/main/java/com/livefront/bridgesample/main/model/Scenario.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/main/model/Scenario.kt
@@ -1,7 +1,6 @@
 package com.livefront.bridgesample.main.model
 
 import android.content.Context
-import android.content.Intent
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.scenario.activity.LargeDataActivity
 import com.livefront.bridgesample.scenario.activity.NonBridgeLargeDataActivity
@@ -13,11 +12,11 @@ fun getScenarios(context: Context): List<MainItem> = listOf(
         MainItem(
                 R.string.large_data_scenario_title,
                 R.string.large_data_scenario_description,
-                Intent(context, LargeDataActivity::class.java)
+                LargeDataActivity.getNavigationIntent(context)
         ),
         MainItem(
                 R.string.non_bridge_large_data_scenario_title,
                 R.string.non_bridge_large_data_scenario_description,
-                Intent(context, NonBridgeLargeDataActivity::class.java)
+                NonBridgeLargeDataActivity.getNavigationIntent(context)
         )
 )

--- a/bridgesample/src/main/java/com/livefront/bridgesample/main/model/Scenario.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/main/model/Scenario.kt
@@ -2,8 +2,11 @@ package com.livefront.bridgesample.main.model
 
 import android.content.Context
 import com.livefront.bridgesample.R
+import com.livefront.bridgesample.scenario.activity.FragmentContainerActivity
 import com.livefront.bridgesample.scenario.activity.LargeDataActivity
 import com.livefront.bridgesample.scenario.activity.NonBridgeLargeDataActivity
+import com.livefront.bridgesample.scenario.fragment.LargeDataFragment
+import com.livefront.bridgesample.scenario.fragment.NonBridgeLargeDataFragment
 
 /**
  * This is the list of all Bridge scenarios demonstrated in this app.
@@ -18,5 +21,21 @@ fun getScenarios(context: Context): List<MainItem> = listOf(
                 R.string.non_bridge_large_data_scenario_title,
                 R.string.non_bridge_large_data_scenario_description,
                 NonBridgeLargeDataActivity.getNavigationIntent(context)
+        ),
+        MainItem(
+                R.string.large_data_fragment_scenario_title,
+                R.string.large_data_fragment_scenario_description,
+                FragmentContainerActivity.getNavigationIntent(
+                        context,
+                        LargeDataFragment.getFragmentData()
+                )
+        ),
+        MainItem(
+                R.string.non_bridge_large_data_fragment_scenario_title,
+                R.string.non_bridge_large_data_fragment_scenario_description,
+                FragmentContainerActivity.getNavigationIntent(
+                        context,
+                        NonBridgeLargeDataFragment.getFragmentData()
+                )
         )
 )

--- a/bridgesample/src/main/java/com/livefront/bridgesample/main/model/Scenario.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/main/model/Scenario.kt
@@ -7,6 +7,8 @@ import com.livefront.bridgesample.scenario.activity.LargeDataActivity
 import com.livefront.bridgesample.scenario.activity.NonBridgeLargeDataActivity
 import com.livefront.bridgesample.scenario.fragment.LargeDataFragment
 import com.livefront.bridgesample.scenario.fragment.NonBridgeLargeDataFragment
+import com.livefront.bridgesample.scenario.fragment.StatePagerArguments
+import com.livefront.bridgesample.scenario.fragment.StatePagerFragment
 
 /**
  * This is the list of all Bridge scenarios demonstrated in this app.
@@ -36,6 +38,30 @@ fun getScenarios(context: Context): List<MainItem> = listOf(
                 FragmentContainerActivity.getNavigationIntent(
                         context,
                         NonBridgeLargeDataFragment.getFragmentData()
+                )
+        ),
+        MainItem(
+                R.string.state_pager_scenario_title,
+                R.string.state_pager_scenario_description,
+                FragmentContainerActivity.getNavigationIntent(
+                        context,
+                        StatePagerFragment.getFragmentData(
+                                StatePagerArguments(
+                                        StatePagerFragment.Mode.BRIDGE
+                                )
+                        )
+                )
+        ),
+        MainItem(
+                R.string.non_bridge_state_pager_scenario_title,
+                R.string.non_bridge_state_pager_scenario_description,
+                FragmentContainerActivity.getNavigationIntent(
+                        context,
+                        StatePagerFragment.getFragmentData(
+                                StatePagerArguments(
+                                        StatePagerFragment.Mode.NON_BRIDGE
+                                )
+                        )
                 )
         )
 )

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/FragmentContainerActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/FragmentContainerActivity.kt
@@ -1,0 +1,74 @@
+package com.livefront.bridgesample.scenario.activity
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.os.Parcelable
+import android.support.annotation.StringRes
+import android.support.v4.app.Fragment
+import android.view.MenuItem
+import com.livefront.bridgesample.R
+import com.livefront.bridgesample.base.BridgeBaseActivity
+import com.livefront.bridgesample.scenario.activity.FragmentContainerActivity.Companion.getNavigationIntent
+import com.livefront.bridgesample.util.handleHomeAsBack
+import com.livefront.bridgesample.util.setHomeAsUpToolbar
+import kotlinx.android.parcel.Parcelize
+import kotlinx.android.synthetic.main.basic_toolbar.toolbar
+
+/**
+ * A simple [Activity] with a container in which an initial [Fragment] may be placed. This is
+ * done by supplying [FragmentData] via the [getNavigationIntent] method.
+ */
+class FragmentContainerActivity : BridgeBaseActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_fragment_container)
+
+        val data = getFragmentData(this)
+        setHomeAsUpToolbar(toolbar, data.titleRes)
+
+        if (savedInstanceState != null) return
+
+        val fragment = Fragment.instantiate(
+                this,
+                data.fragmentClass.name,
+                data.fragmentBundle
+        )
+        supportFragmentManager
+                .beginTransaction()
+                .replace(R.id.container, fragment)
+                .commit()
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem) = handleHomeAsBack(item) {
+        super.onOptionsItemSelected(item)
+    }
+
+    companion object {
+        private const val FRAGMENT_DATA_KEY = "data-key"
+
+        fun getFragmentData(
+            activity: FragmentContainerActivity
+        ): FragmentData = activity
+                .intent
+                .getParcelableExtra(FRAGMENT_DATA_KEY)
+
+        fun getNavigationIntent(
+            context: Context,
+            fragmentData: FragmentData
+        ) = Intent(context, FragmentContainerActivity::class.java).apply {
+            putExtra(FRAGMENT_DATA_KEY, fragmentData)
+        }
+    }
+}
+
+/**
+ * Used to determine the initial [Fragment] to show in a [FragmentContainerActivity].
+ */
+@Parcelize
+data class FragmentData(
+    @StringRes val titleRes: Int,
+    val fragmentClass: Class<out Fragment>,
+    val fragmentBundle: Bundle?
+) : Parcelable

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/LargeDataActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/LargeDataActivity.kt
@@ -1,5 +1,6 @@
 package com.livefront.bridgesample.scenario.activity
 
+import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
@@ -37,5 +38,12 @@ class LargeDataActivity : BridgeBaseActivity() {
     override fun onSaveInstanceState(outState: Bundle) {
         savedBitmap = bitmapGeneratorView.generatedBitmap
         super.onSaveInstanceState(outState)
+    }
+
+    companion object {
+        fun getNavigationIntent(context: Context) = Intent(
+                context,
+                LargeDataActivity::class.java
+        )
     }
 }

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/LargeDataActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/LargeDataActivity.kt
@@ -25,6 +25,7 @@ class LargeDataActivity : BridgeBaseActivity() {
         bitmapGeneratorView.apply {
             setHeaderText(R.string.large_data_header)
             generatedBitmap = savedBitmap
+            onBitmapGeneratedListener = { savedBitmap = it }
             onNavigateButtonClickListener = {
                 startActivity(Intent(this@LargeDataActivity, SuccessActivity::class.java))
             }
@@ -33,11 +34,6 @@ class LargeDataActivity : BridgeBaseActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem) = handleHomeAsBack(item) {
         super.onOptionsItemSelected(item)
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        savedBitmap = bitmapGeneratorView.generatedBitmap
-        super.onSaveInstanceState(outState)
     }
 
     companion object {

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/NonBridgeLargeDataActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/NonBridgeLargeDataActivity.kt
@@ -25,6 +25,7 @@ class NonBridgeLargeDataActivity : NonBridgeBaseActivity() {
         bitmapGeneratorView.apply {
             setHeaderText(R.string.non_bridge_large_data_header)
             generatedBitmap = savedBitmap
+            onBitmapGeneratedListener = { savedBitmap = it }
             onNavigateButtonClickListener = {
                 startActivity(Intent(this@NonBridgeLargeDataActivity, SuccessActivity::class.java))
             }
@@ -33,11 +34,6 @@ class NonBridgeLargeDataActivity : NonBridgeBaseActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem) = handleHomeAsBack(item) {
         super.onOptionsItemSelected(item)
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        savedBitmap = bitmapGeneratorView.generatedBitmap
-        super.onSaveInstanceState(outState)
     }
 
     companion object {

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/NonBridgeLargeDataActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/NonBridgeLargeDataActivity.kt
@@ -1,5 +1,6 @@
 package com.livefront.bridgesample.scenario.activity
 
+import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
@@ -37,5 +38,12 @@ class NonBridgeLargeDataActivity : NonBridgeBaseActivity() {
     override fun onSaveInstanceState(outState: Bundle) {
         savedBitmap = bitmapGeneratorView.generatedBitmap
         super.onSaveInstanceState(outState)
+    }
+
+    companion object {
+        fun getNavigationIntent(context: Context) = Intent(
+                context,
+                NonBridgeLargeDataActivity::class.java
+        )
     }
 }

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/LargeDataFragment.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/LargeDataFragment.kt
@@ -1,0 +1,76 @@
+package com.livefront.bridgesample.scenario.fragment
+
+import android.content.Intent
+import android.graphics.Bitmap
+import android.os.Bundle
+import android.os.Parcelable
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.evernote.android.state.State
+import com.livefront.bridgesample.R
+import com.livefront.bridgesample.base.BridgeBaseFragment
+import com.livefront.bridgesample.scenario.activity.FragmentData
+import com.livefront.bridgesample.scenario.activity.SuccessActivity
+import kotlinx.android.parcel.Parcelize
+import kotlinx.android.synthetic.main.activity_large_data.bitmapGeneratorView
+
+class LargeDataFragment : BridgeBaseFragment() {
+    override val shouldClearOnDestroy: Boolean
+        get() = getArguments(this).shouldClearOnDestroy
+
+    @State
+    var savedBitmap: Bitmap? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? = inflater.inflate(R.layout.fragment_large_data, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        bitmapGeneratorView.apply {
+            setHeaderText(R.string.large_data_header)
+            generatedBitmap = savedBitmap
+            onBitmapGeneratedListener = { savedBitmap = it }
+            onNavigateButtonClickListener = {
+                startActivity(Intent(context!!, SuccessActivity::class.java))
+            }
+        }
+    }
+
+    companion object {
+        private const val ARGUMENTS_KEY = "arguments"
+
+        fun getArguments(
+            fragment: LargeDataFragment
+        ): LargeDataArguments = fragment
+                .arguments!!
+                .getParcelable(ARGUMENTS_KEY)
+
+        fun getFragmentData(
+            largeDataArguments: LargeDataArguments = LargeDataArguments()
+        ) = FragmentData(
+                R.string.large_data_screen_title,
+                LargeDataFragment::class.java,
+                getInitialArguments(largeDataArguments)
+        )
+
+        fun getInitialArguments(
+            largeDataArguments: LargeDataArguments = LargeDataArguments()
+        ) = Bundle().apply {
+            putParcelable(ARGUMENTS_KEY, largeDataArguments)
+        }
+
+        fun newInstance(
+            largeDataArguments: LargeDataArguments = LargeDataArguments()
+        ) = LargeDataFragment().apply {
+            arguments = getInitialArguments(largeDataArguments)
+        }
+    }
+}
+
+@Parcelize
+data class LargeDataArguments(
+    val shouldClearOnDestroy: Boolean = true
+) : Parcelable

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/NonBridgeLargeDataFragment.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/NonBridgeLargeDataFragment.kt
@@ -1,0 +1,50 @@
+package com.livefront.bridgesample.scenario.fragment
+
+import android.content.Intent
+import android.graphics.Bitmap
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.evernote.android.state.State
+import com.livefront.bridgesample.R
+import com.livefront.bridgesample.base.NonBridgeBaseFragment
+import com.livefront.bridgesample.scenario.activity.FragmentData
+import com.livefront.bridgesample.scenario.activity.SuccessActivity
+import kotlinx.android.synthetic.main.activity_large_data.bitmapGeneratorView
+
+class NonBridgeLargeDataFragment : NonBridgeBaseFragment() {
+    @State
+    var savedBitmap: Bitmap? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? = inflater.inflate(R.layout.fragment_large_data, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        bitmapGeneratorView.apply {
+            setHeaderText(R.string.non_bridge_large_data_header)
+            generatedBitmap = savedBitmap
+            onBitmapGeneratedListener = { savedBitmap = it }
+            onNavigateButtonClickListener = {
+                startActivity(Intent(context!!, SuccessActivity::class.java))
+            }
+        }
+    }
+
+    companion object {
+        fun getFragmentData() = FragmentData(
+                R.string.non_bridge_large_data_screen_title,
+                NonBridgeLargeDataFragment::class.java,
+                getInitialArguments()
+        )
+
+        fun getInitialArguments() = Bundle()
+
+        fun newInstance() = NonBridgeLargeDataFragment().apply {
+            arguments = getInitialArguments()
+        }
+    }
+}

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/StatePagerFragment.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/StatePagerFragment.kt
@@ -1,0 +1,93 @@
+package com.livefront.bridgesample.scenario.fragment
+
+import android.os.Bundle
+import android.os.Parcelable
+import android.support.v4.app.Fragment
+import android.support.v4.app.FragmentStatePagerAdapter
+import android.support.v4.view.ViewPager
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.livefront.bridge.Bridge
+import com.livefront.bridgesample.R
+import com.livefront.bridgesample.base.BridgeBaseFragment
+import com.livefront.bridgesample.scenario.activity.FragmentData
+import kotlinx.android.parcel.Parcelize
+import kotlinx.android.synthetic.main.fragment_pager.viewPager
+
+/**
+ * A [Fragment] with a [ViewPager] that uses a [FragmentStatePagerAdapter]. This illustrates how
+ * we currently must omit the call to [Bridge.clear] in [Fragment.onDestroy] of the child
+ * Fragments. Failure to do so will lose data as you page between screens.
+ */
+class StatePagerFragment : BridgeBaseFragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? = inflater.inflate(R.layout.fragment_pager, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewPager.adapter = object : FragmentStatePagerAdapter(childFragmentManager) {
+            override fun getItem(
+                position: Int
+            ): Fragment = when (getArguments(this@StatePagerFragment).mode) {
+                Mode.BRIDGE -> LargeDataFragment.newInstance(
+                        // Note here that we specifically specify that the data should not be
+                        // cleared in onDestroy because a FragmentStatePagerAdapter will destroy
+                        // Fragments while still manually holding their Bundles for reuse later.
+                        // A future feature may allow clearing to be "deferred" when some parent
+                        // is being cleared.
+                        LargeDataArguments(shouldClearOnDestroy = false)
+                )
+                Mode.NON_BRIDGE -> NonBridgeLargeDataFragment.newInstance()
+            }
+
+            override fun getCount(): Int = NUMBER_OF_PAGES
+
+            override fun getPageTitle(position: Int): CharSequence? = position.toString()
+        }
+    }
+
+    companion object {
+        private const val ARGUMENTS_KEY = "arguments"
+        private const val NUMBER_OF_PAGES = 10
+
+        fun getArguments(
+            fragment: StatePagerFragment
+        ): StatePagerArguments = fragment
+                .arguments!!
+                .getParcelable(ARGUMENTS_KEY)
+
+        fun getFragmentData(arguments: StatePagerArguments) = FragmentData(
+                when (arguments.mode) {
+                    Mode.BRIDGE -> R.string.state_pager_screen_title
+                    Mode.NON_BRIDGE -> R.string.non_bridge_state_pager_screen_title
+                },
+                StatePagerFragment::class.java,
+                getInitialArguments(arguments)
+        )
+
+        fun getInitialArguments(arguments: StatePagerArguments) = Bundle().apply {
+            putParcelable(ARGUMENTS_KEY, arguments)
+        }
+
+        fun newInstance(arguments: StatePagerArguments) = StatePagerFragment().apply {
+            this.arguments = getInitialArguments(arguments)
+        }
+    }
+
+    /**
+     * Specifies whether or not Bridge will be used for the child Fragments.
+     */
+    enum class Mode {
+        BRIDGE,
+        NON_BRIDGE
+    }
+}
+
+@Parcelize
+data class StatePagerArguments(
+    val mode: StatePagerFragment.Mode
+) : Parcelable

--- a/bridgesample/src/main/res/layout/activity_fragment_container.xml
+++ b/bridgesample/src/main/res/layout/activity_fragment_container.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".scenario.activity.LargeDataActivity">
+
+    <include
+        android:id="@+id/toolbar"
+        layout="@layout/basic_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true" />
+
+    <FrameLayout
+        android:id="@+id/container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@id/toolbar"
+        android:layout_alignParentBottom="true" />
+
+</RelativeLayout>

--- a/bridgesample/src/main/res/layout/fragment_large_data.xml
+++ b/bridgesample/src/main/res/layout/fragment_large_data.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.livefront.bridgesample.common.view.BitmapGeneratorView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/bitmapGeneratorView"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/bridgesample/src/main/res/layout/fragment_pager.xml
+++ b/bridgesample/src/main/res/layout/fragment_pager.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v4.view.ViewPager
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/viewPager"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <android.support.design.widget.TabLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top"
+        app:tabBackground="@color/colorPrimary"
+        app:tabIndicatorColor="@android:color/white"
+        app:tabMode="scrollable"
+        app:tabTextColor="@android:color/white" />
+
+</android.support.v4.view.ViewPager>

--- a/bridgesample/src/main/res/values/strings.xml
+++ b/bridgesample/src/main/res/values/strings.xml
@@ -8,12 +8,6 @@
     <string name="non_bridge_large_data_header">Generating data and navigating should trigger a crash</string>
     <string name="restored_from_saved_state">Imaged Restored from Saved State</string>
 
-    <!-- Large Data Screen -->
-    <string name="large_data_screen_title">Large Data with Bridge</string>
-
-    <!-- Non-Bridge Large Data Screen -->
-    <string name="non_bridge_large_data_screen_title">Large Data without Bridge</string>
-
     <!-- Scenarios -->
     <string name="large_data_fragment_scenario_description">with Bridge</string>
     <string name="large_data_fragment_scenario_title">Fragment with Large Data</string>
@@ -23,5 +17,16 @@
     <string name="non_bridge_large_data_fragment_scenario_description">without Bridge</string>
     <string name="non_bridge_large_data_scenario_description">without Bridge</string>
     <string name="non_bridge_large_data_scenario_title">Activity with Large Data</string>
+    <string name="non_bridge_state_pager_scenario_description">without Bridge</string>
+    <string name="non_bridge_state_pager_scenario_title">Fragment State Pager</string>
     <string name="scenario_success_message">Navigation Successful!</string>
+    <string name="state_pager_scenario_description">with Bridge</string>
+    <string name="state_pager_scenario_title">Fragment State Pager</string>
+
+    <!-- Screen titles -->
+    <string name="large_data_screen_title">Large Data with Bridge</string>
+    <string name="non_bridge_large_data_screen_title">Large Data without Bridge</string>
+    <string name="non_bridge_state_pager_screen_title">State Pager without Bridge</string>
+    <string name="state_pager_screen_title">State Pager with Bridge</string>
+
 </resources>

--- a/bridgesample/src/main/res/values/strings.xml
+++ b/bridgesample/src/main/res/values/strings.xml
@@ -15,8 +15,12 @@
     <string name="non_bridge_large_data_screen_title">Large Data without Bridge</string>
 
     <!-- Scenarios -->
+    <string name="large_data_fragment_scenario_description">with Bridge</string>
+    <string name="large_data_fragment_scenario_title">Fragment with Large Data</string>
     <string name="large_data_scenario_description">with Bridge</string>
     <string name="large_data_scenario_title">Activity with Large Data</string>
+    <string name="non_bridge_large_data_fragment_scenario_title">Fragment with Large Data</string>
+    <string name="non_bridge_large_data_fragment_scenario_description">without Bridge</string>
     <string name="non_bridge_large_data_scenario_description">without Bridge</string>
     <string name="non_bridge_large_data_scenario_title">Activity with Large Data</string>
     <string name="scenario_success_message">Navigation Successful!</string>


### PR DESCRIPTION
This PR adds several scenarios involving Fragments to the sample app:

- The `LargeDataFragment` / `NonBridgeLargeDataFragment` are simply `Fragment` versions of the existing `Activity` scenarios.
- `StatePagerFragment` allows for a test of a `ViewPager` using a `FragmentStatePagerAdapter` with either a series of  `LargeDataFragment` or `NonBridgeLargeDataFragment` as children. Note that a `FragmentStatePagerAdapter` was chosen here over a `FragmentPagerAdapter` because there is a specific bug due to calling `Bridge.clear` in this scenario that can be worked around but still needs a more robust solution. See https://github.com/livefront/bridge/issues/17 for details.

Note that I may still add more Fragment-based scenarios later, such as flow with a backstack.

<img src="https://user-images.githubusercontent.com/4624669/58593201-e47d4700-822f-11e9-9aab-7a3835cf9e4c.gif" width=300 />
