### PR TITLE
Bridge for views

### DIFF
--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -105,9 +105,15 @@ class BridgeDelegate {
      * for this task (and any others currently running in the background) to complete before
      * proceeding in order to prevent the app from becoming fully "stopped" (and therefore killable
      * by the OS before the data is saved).
+     *
+     * Note that if there is a configuration change taking place, no action will be taken.
      */
-    private void queueDiskWriting(@NonNull final String uuid,
-                                  @NonNull final Bundle bundle) {
+    private void queueDiskWritingIfNecessary(@NonNull final String uuid,
+                                             @NonNull final Bundle bundle) {
+        if (mIsConfigChange) {
+            // Don't process the Bundle or write it to disk during a config change
+            return;
+        }
         Runnable runnable = new Runnable() {
             @Override
             public void run() {
@@ -248,11 +254,7 @@ class BridgeDelegate {
         }
         WrapperUtils.wrapOptimizedObjects(bundle);
         mUuidBundleMap.put(uuid, bundle);
-        if (mIsConfigChange) {
-            // Don't process the Bundle or write it to disk during a config change
-            return;
-        }
-        queueDiskWriting(uuid, bundle);
+        queueDiskWritingIfNecessary(uuid, bundle);
     }
 
     private void writeToDisk(@NonNull String uuid,

--- a/bridge/src/main/java/com/livefront/bridge/SavedStateHandler.java
+++ b/bridge/src/main/java/com/livefront/bridge/SavedStateHandler.java
@@ -4,6 +4,10 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+/**
+ * A handler for generic, non-{@link android.view.View} objects. To save the state of Views, see
+ * {@link ViewSavedStateHandler}.
+ */
 public interface SavedStateHandler {
 
     void saveInstanceState(@NonNull Object target, @NonNull Bundle state);

--- a/bridge/src/main/java/com/livefront/bridge/ViewSavedStateHandler.java
+++ b/bridge/src/main/java/com/livefront/bridge/ViewSavedStateHandler.java
@@ -1,0 +1,20 @@
+package com.livefront.bridge;
+
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.view.View;
+
+/**
+ * A handler specifically for saving and restoring the state of {@link android.view.View} objects.
+ */
+public interface ViewSavedStateHandler {
+    @NonNull
+    <T extends View> Parcelable saveInstanceState(@NonNull T target,
+                                                  @Nullable Parcelable parentState);
+
+    @Nullable
+    <T extends View> Parcelable restoreInstanceState(@NonNull T target,
+                                                     @Nullable Parcelable state);
+
+}

--- a/bridgesample/src/main/AndroidManifest.xml
+++ b/bridgesample/src/main/AndroidManifest.xml
@@ -34,6 +34,8 @@
 
         <activity android:name=".scenario.activity.SuccessActivity" />
 
+        <activity android:name=".scenario.activity.ViewContainerActivity" />
+
     </application>
 
 </manifest>

--- a/bridgesample/src/main/java/com/livefront/bridgesample/app/BridgeSampleApplication.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/app/BridgeSampleApplication.kt
@@ -2,9 +2,12 @@ package com.livefront.bridgesample.app
 
 import android.app.Application
 import android.os.Bundle
+import android.os.Parcelable
+import android.view.View
 import com.evernote.android.state.StateSaver
 import com.livefront.bridge.Bridge
 import com.livefront.bridge.SavedStateHandler
+import com.livefront.bridge.ViewSavedStateHandler
 
 class BridgeSampleApplication : Application() {
     override fun onCreate() {
@@ -19,6 +22,17 @@ class BridgeSampleApplication : Application() {
                     override fun restoreInstanceState(target: Any, state: Bundle?) {
                         StateSaver.restoreInstanceState(target, state)
                     }
+                },
+                object : ViewSavedStateHandler {
+                    override fun <T : View> saveInstanceState(
+                        target: T,
+                        parentState: Parcelable?
+                    ): Parcelable = StateSaver.saveInstanceState(target, parentState)
+
+                    override fun <T : View> restoreInstanceState(
+                        target: T,
+                        state: Parcelable?
+                    ): Parcelable? = StateSaver.restoreInstanceState(target, state)
                 }
         )
     }

--- a/bridgesample/src/main/java/com/livefront/bridgesample/common/view/BitmapGeneratorView.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/common/view/BitmapGeneratorView.kt
@@ -1,11 +1,14 @@
 package com.livefront.bridgesample.common.view
 
+import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import android.graphics.Bitmap
 import android.support.annotation.StringRes
 import android.util.AttributeSet
 import android.widget.RelativeLayout
 import com.livefront.bridgesample.R
+import com.livefront.bridgesample.scenario.activity.SuccessActivity
 import com.livefront.bridgesample.util.generateNoisyStripedBitmap
 import kotlinx.android.synthetic.main.view_bitmap_generator_content.view.generateDataButton
 import kotlinx.android.synthetic.main.view_bitmap_generator_content.view.headerText
@@ -17,7 +20,8 @@ import kotlinx.android.synthetic.main.view_bitmap_generator_content.view.statusT
  * A view that generates a [Bitmap] when clicking on a button. This `Bitmap` can then be retrieved
  * as the [generatedBitmap] in order to test saving / restoring it. The
  * [onNavigateButtonClickListener] may be set to provide some action when the corresponding button
- * is clicked.
+ * is clicked. If no such listener is set, the default behavior is to navigate to the
+ * [SuccessActivity].
  */
 class BitmapGeneratorView @JvmOverloads constructor(
     context: Context,
@@ -43,7 +47,13 @@ class BitmapGeneratorView @JvmOverloads constructor(
 
     init {
         inflate(context, R.layout.view_bitmap_generator_content, this)
-        navigateButton.setOnClickListener { onNavigateButtonClickListener?.invoke() }
+        navigateButton.setOnClickListener {
+            onNavigateButtonClickListener
+                    ?.invoke()
+                    ?: (context as Activity).startActivity(
+                            Intent(context, SuccessActivity::class.java)
+                    )
+        }
         generateDataButton.setOnClickListener {
             generateDataButton.isEnabled = false
             generateNoisyStripedBitmap { bitmap ->

--- a/bridgesample/src/main/java/com/livefront/bridgesample/main/model/Scenario.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/main/model/Scenario.kt
@@ -5,6 +5,8 @@ import com.livefront.bridgesample.R
 import com.livefront.bridgesample.scenario.activity.FragmentContainerActivity
 import com.livefront.bridgesample.scenario.activity.LargeDataActivity
 import com.livefront.bridgesample.scenario.activity.NonBridgeLargeDataActivity
+import com.livefront.bridgesample.scenario.activity.ViewContainerActivity
+import com.livefront.bridgesample.scenario.activity.ViewData
 import com.livefront.bridgesample.scenario.fragment.LargeDataFragment
 import com.livefront.bridgesample.scenario.fragment.NonBridgeLargeDataFragment
 import com.livefront.bridgesample.scenario.fragment.StatePagerArguments
@@ -61,6 +63,28 @@ fun getScenarios(context: Context): List<MainItem> = listOf(
                                 StatePagerArguments(
                                         StatePagerFragment.Mode.NON_BRIDGE
                                 )
+                        )
+                )
+        ),
+        MainItem(
+                R.string.large_data_view_scenario_title,
+                R.string.large_data_view_scenario_description,
+                ViewContainerActivity.getNavigationIntent(
+                        context,
+                        ViewData(
+                                R.string.large_data_screen_title,
+                                R.layout.view_large_data_inflatable
+                        )
+                )
+        ),
+        MainItem(
+                R.string.non_bridge_large_data_view_scenario_title,
+                R.string.non_bridge_large_data_view_scenario_description,
+                ViewContainerActivity.getNavigationIntent(
+                        context,
+                        ViewData(
+                                R.string.non_bridge_large_data_screen_title,
+                                R.layout.non_bridge_large_data_view_inflatable
                         )
                 )
         )

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/LargeDataActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/LargeDataActivity.kt
@@ -26,9 +26,6 @@ class LargeDataActivity : BridgeBaseActivity() {
             setHeaderText(R.string.large_data_header)
             generatedBitmap = savedBitmap
             onBitmapGeneratedListener = { savedBitmap = it }
-            onNavigateButtonClickListener = {
-                startActivity(Intent(this@LargeDataActivity, SuccessActivity::class.java))
-            }
         }
     }
 

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/NonBridgeLargeDataActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/NonBridgeLargeDataActivity.kt
@@ -26,9 +26,6 @@ class NonBridgeLargeDataActivity : NonBridgeBaseActivity() {
             setHeaderText(R.string.non_bridge_large_data_header)
             generatedBitmap = savedBitmap
             onBitmapGeneratedListener = { savedBitmap = it }
-            onNavigateButtonClickListener = {
-                startActivity(Intent(this@NonBridgeLargeDataActivity, SuccessActivity::class.java))
-            }
         }
     }
 

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/ViewContainerActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/ViewContainerActivity.kt
@@ -1,0 +1,66 @@
+package com.livefront.bridgesample.scenario.activity
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.os.Parcelable
+import android.support.annotation.LayoutRes
+import android.support.annotation.StringRes
+import android.support.v4.app.Fragment
+import android.view.MenuItem
+import android.view.View
+import com.livefront.bridgesample.R
+import com.livefront.bridgesample.base.BridgeBaseActivity
+import com.livefront.bridgesample.scenario.activity.FragmentContainerActivity.Companion.getNavigationIntent
+import com.livefront.bridgesample.scenario.activity.ViewContainerActivity.Companion.getNavigationIntent
+import com.livefront.bridgesample.util.handleHomeAsBack
+import com.livefront.bridgesample.util.setHomeAsUpToolbar
+import kotlinx.android.parcel.Parcelize
+import kotlinx.android.synthetic.main.activity_view_container.viewContainer
+import kotlinx.android.synthetic.main.basic_toolbar.toolbar
+
+/**
+ * A simple [Activity] with a container in which an initial [Fragment] may be placed. This is
+ * done by supplying [ViewData] via the [getNavigationIntent] method.
+ */
+class ViewContainerActivity : BridgeBaseActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_view_container)
+        val data = getViewData(this)
+        setHomeAsUpToolbar(toolbar, data.titleRes)
+        layoutInflater.inflate(data.viewRes, viewContainer, true)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem) = handleHomeAsBack(item) {
+        super.onOptionsItemSelected(item)
+    }
+
+    companion object {
+        private const val DATA_KEY = "data"
+
+        /**
+         * Creates the appropriate [Intent] to show the [View] with the layout resource ID given
+         * by [viewRes].
+         */
+        fun getNavigationIntent(
+            context: Context,
+            viewData: ViewData
+        ) = Intent(context, ViewContainerActivity::class.java).apply {
+            putExtra(DATA_KEY, viewData)
+        }
+
+        fun getViewData(
+            activity: ViewContainerActivity
+        ): ViewData = activity
+                .intent
+                .getParcelableExtra(DATA_KEY)
+    }
+}
+
+@Parcelize
+data class ViewData(
+    @StringRes val titleRes: Int,
+    @LayoutRes val viewRes: Int
+) : Parcelable

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/LargeDataFragment.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/LargeDataFragment.kt
@@ -1,6 +1,5 @@
 package com.livefront.bridgesample.scenario.fragment
 
-import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
 import android.os.Parcelable
@@ -11,7 +10,6 @@ import com.evernote.android.state.State
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.base.BridgeBaseFragment
 import com.livefront.bridgesample.scenario.activity.FragmentData
-import com.livefront.bridgesample.scenario.activity.SuccessActivity
 import kotlinx.android.parcel.Parcelize
 import kotlinx.android.synthetic.main.activity_large_data.bitmapGeneratorView
 
@@ -33,9 +31,6 @@ class LargeDataFragment : BridgeBaseFragment() {
             setHeaderText(R.string.large_data_header)
             generatedBitmap = savedBitmap
             onBitmapGeneratedListener = { savedBitmap = it }
-            onNavigateButtonClickListener = {
-                startActivity(Intent(context!!, SuccessActivity::class.java))
-            }
         }
     }
 

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/NonBridgeLargeDataFragment.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/NonBridgeLargeDataFragment.kt
@@ -1,6 +1,5 @@
 package com.livefront.bridgesample.scenario.fragment
 
-import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -10,7 +9,6 @@ import com.evernote.android.state.State
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.base.NonBridgeBaseFragment
 import com.livefront.bridgesample.scenario.activity.FragmentData
-import com.livefront.bridgesample.scenario.activity.SuccessActivity
 import kotlinx.android.synthetic.main.activity_large_data.bitmapGeneratorView
 
 class NonBridgeLargeDataFragment : NonBridgeBaseFragment() {
@@ -28,9 +26,6 @@ class NonBridgeLargeDataFragment : NonBridgeBaseFragment() {
             setHeaderText(R.string.non_bridge_large_data_header)
             generatedBitmap = savedBitmap
             onBitmapGeneratedListener = { savedBitmap = it }
-            onNavigateButtonClickListener = {
-                startActivity(Intent(context!!, SuccessActivity::class.java))
-            }
         }
     }
 

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/view/LargeDataView.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/view/LargeDataView.kt
@@ -1,0 +1,38 @@
+package com.livefront.bridgesample.scenario.view
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.os.Parcelable
+import android.util.AttributeSet
+import android.widget.FrameLayout
+import com.evernote.android.state.State
+import com.livefront.bridge.Bridge
+import com.livefront.bridgesample.R
+import kotlinx.android.synthetic.main.view_large_data_content.view.bitmapGeneratorView
+
+class LargeDataView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+    defStyleRes: Int = 0
+) : FrameLayout(context, attrs, defStyleAttr, defStyleRes) {
+    @State
+    var savedBitmap: Bitmap? = null
+
+    init {
+        inflate(context, R.layout.view_large_data_content, this)
+        bitmapGeneratorView.apply {
+            setHeaderText(R.string.large_data_header)
+            onBitmapGeneratedListener = { savedBitmap = it }
+        }
+    }
+
+    override fun onSaveInstanceState(): Parcelable? {
+        return Bridge.saveInstanceState(this, super.onSaveInstanceState())
+    }
+
+    override fun onRestoreInstanceState(state: Parcelable?) {
+        super.onRestoreInstanceState(Bridge.restoreInstanceState(this, state))
+        bitmapGeneratorView.generatedBitmap = savedBitmap
+    }
+}

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/view/NonBridgeLargeDataView.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/view/NonBridgeLargeDataView.kt
@@ -1,0 +1,38 @@
+package com.livefront.bridgesample.scenario.view
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.os.Parcelable
+import android.util.AttributeSet
+import android.widget.FrameLayout
+import com.evernote.android.state.State
+import com.evernote.android.state.StateSaver
+import com.livefront.bridgesample.R
+import kotlinx.android.synthetic.main.view_large_data_content.view.bitmapGeneratorView
+
+class NonBridgeLargeDataView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+    defStyleRes: Int = 0
+) : FrameLayout(context, attrs, defStyleAttr, defStyleRes) {
+    @State
+    var savedBitmap: Bitmap? = null
+
+    init {
+        inflate(context, R.layout.view_large_data_content, this)
+        bitmapGeneratorView.apply {
+            setHeaderText(R.string.non_bridge_large_data_header)
+            onBitmapGeneratedListener = { savedBitmap = it }
+        }
+    }
+
+    override fun onSaveInstanceState(): Parcelable? {
+        return StateSaver.saveInstanceState(this, super.onSaveInstanceState())
+    }
+
+    override fun onRestoreInstanceState(state: Parcelable?) {
+        super.onRestoreInstanceState(StateSaver.restoreInstanceState(this, state))
+        bitmapGeneratorView.generatedBitmap = savedBitmap
+    }
+}

--- a/bridgesample/src/main/res/layout/activity_view_container.xml
+++ b/bridgesample/src/main/res/layout/activity_view_container.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".scenario.activity.ViewContainerActivity">
+
+    <include
+        android:id="@+id/toolbar"
+        layout="@layout/basic_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true" />
+
+    <FrameLayout
+        android:id="@+id/viewContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@id/toolbar"
+        android:layout_alignParentBottom="true" />
+
+</RelativeLayout>

--- a/bridgesample/src/main/res/layout/non_bridge_large_data_view_inflatable.xml
+++ b/bridgesample/src/main/res/layout/non_bridge_large_data_view_inflatable.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.livefront.bridgesample.scenario.view.NonBridgeLargeDataView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/largeDataView"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/bridgesample/src/main/res/layout/view_large_data_content.xml
+++ b/bridgesample/src/main/res/layout/view_large_data_content.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:parentTag="android.widget.FrameLayout">
+
+    <com.livefront.bridgesample.common.view.BitmapGeneratorView
+        android:id="@+id/bitmapGeneratorView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</merge>

--- a/bridgesample/src/main/res/layout/view_large_data_inflatable.xml
+++ b/bridgesample/src/main/res/layout/view_large_data_inflatable.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.livefront.bridgesample.scenario.view.LargeDataView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/largeDataView"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/bridgesample/src/main/res/values/strings.xml
+++ b/bridgesample/src/main/res/values/strings.xml
@@ -13,10 +13,14 @@
     <string name="large_data_fragment_scenario_title">Fragment with Large Data</string>
     <string name="large_data_scenario_description">with Bridge</string>
     <string name="large_data_scenario_title">Activity with Large Data</string>
+    <string name="large_data_view_scenario_description">with Bridge</string>
+    <string name="large_data_view_scenario_title">View with Large Data</string>
     <string name="non_bridge_large_data_fragment_scenario_title">Fragment with Large Data</string>
     <string name="non_bridge_large_data_fragment_scenario_description">without Bridge</string>
     <string name="non_bridge_large_data_scenario_description">without Bridge</string>
     <string name="non_bridge_large_data_scenario_title">Activity with Large Data</string>
+    <string name="non_bridge_large_data_view_scenario_description">without Bridge</string>
+    <string name="non_bridge_large_data_view_scenario_title">View with Large Data</string>
     <string name="non_bridge_state_pager_scenario_description">without Bridge</string>
     <string name="non_bridge_state_pager_scenario_title">Fragment State Pager</string>
     <string name="scenario_success_message">Navigation Successful!</string>


### PR DESCRIPTION
This PR adds support for saving the state of `View` objects (see https://github.com/livefront/bridge/issues/10). To do so, you can now pass a `ViewSavedStateHandler` to the `Bridge.initialize` method. Calling `Bridge` in the view then looks like : 

```kotlin
    override fun onSaveInstanceState(): Parcelable? {
        return Bridge.saveInstanceState(this, super.onSaveInstanceState())
    }

    override fun onRestoreInstanceState(state: Parcelable?) {
        super.onRestoreInstanceState(Bridge.restoreInstanceState(this, state))
    }
```

In the process, I've cleaned up `BridgeDelegate` a bit with some helper methods. 

Below is the main update I will be making to the README when this feature is released.

----

<a name="views"></a>
## Bridge for Views

In addition to `Activity`, `Fragment`, presenter, etc. classes, `Bridge` can also be used to assist in saving the state of `View` classes:

```java
    @Override
    protected Parcelable onSaveInstanceState() {
        return Bridge.saveInstanceState(this, super.onSaveInstanceState());
    }

    @Override
    protected void onRestoreInstanceState(Parcelable state) {
        super.onRestoreInstanceState(Bridge.restoreInstanceState(this, state));
    }
```

In order to enable this ability, a `ViewSavedStateHandler` must be passed to the `Bridge.initialize` method. For example:

```java
        Bridge.initialize(
                this,
                new SavedStateHandler() {
                    ...
                },
                new ViewSavedStateHandler() {
                    @NonNull
                    @Override
                    public <T extends View> Parcelable saveInstanceState(
                            @NonNull T target,
                            @Nullable Parcelable parentState) {
                        return Icepick.saveInstanceState(target, parentState);
                    }

                    @Nullable
                    @Override
                    public <T extends View> Parcelable restoreInstanceState(
                            @NonNull T target,
                            @Nullable Parcelable state) {
                        return Icepick.restoreInstanceState(target, state);
                    }
                }
        );
```


