### PR TITLE
Prepare for v1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 Change Log
 ==========
 
+Version 1.2.0 *(2019-05-30)*
+----------------------------
+
+ * `Bridge` can now save the state of `View` objects. You may now optionally provide a `ViewSavedStateHandler` to `Bridge.initialize` in order to unlock this functionality.
+ * Improved performance during configuration changes and when navigating while apps are in the foreground.
+
 Version 1.1.3 *(2018-10-08)*
 ----------------------------
+
  * `Bridge.clear` is now safe to call in `Activity.onDestroy` when "Don't Keep Activities" is enabled.
  * All data is now correctly cleared on fresh launches for apps that do not use `Bridge` in every `Activity`.
  * Min SDK is now 14.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A library for avoiding TransactionTooLargeException during state saving and rest
 * [Motivation](#motivation)
 * [Setup](#setup)
 * [Clearing Data](#clear)
+* [Bridge for Views](#views)
 * [Install](#install)
 * [How Does It Work](#how)
 * [Limitations](#limitations)
@@ -84,6 +85,50 @@ This method is typically safe to call without any additional logic, as it will o
 
 In the event that you might like to migrate away from the use of `Bridge` but ensure that all associated data is cleared, `Bridge.clearAll` may be called at any time.
 
+<a name="views"></a>
+## Bridge for Views
+
+In addition to `Activity`, `Fragment`, presenter, etc. classes, `Bridge` can also be used to assist in saving the state of `View` classes using `View`-specific save and restore methods :
+
+```java
+    @Override
+    protected Parcelable onSaveInstanceState() {
+        return Bridge.saveInstanceState(this, super.onSaveInstanceState());
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Parcelable state) {
+        super.onRestoreInstanceState(Bridge.restoreInstanceState(this, state));
+    }
+```
+
+In order to enable this ability, a `ViewSavedStateHandler` must be passed to the `Bridge.initialize` method. For example:
+
+```java
+        Bridge.initialize(
+                getApplicationContext(),
+                new SavedStateHandler() {
+                    ...
+                },
+                new ViewSavedStateHandler() {
+                    @NonNull
+                    @Override
+                    public <T extends View> Parcelable saveInstanceState(
+                            @NonNull T target,
+                            @Nullable Parcelable parentState) {
+                        return Icepick.saveInstanceState(target, parentState);
+                    }
+
+                    @Nullable
+                    @Override
+                    public <T extends View> Parcelable restoreInstanceState(
+                            @NonNull T target,
+                            @Nullable Parcelable state) {
+                        return Icepick.restoreInstanceState(target, state);
+                    }
+                });
+```
+
 <a name="install"></a>
 ## Install
 
@@ -95,7 +140,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.livefront:bridge:v1.1.3'
+    implementation 'com.github.livefront:bridge:v1.2.0'
 }
 ```
 


### PR DESCRIPTION
This PR prepares for the v1.2.0 release, which includes the changes from https://github.com/livefront/bridge/pull/39, https://github.com/livefront/bridge/pull/40, https://github.com/livefront/bridge/pull/41, https://github.com/livefront/bridge/pull/42, https://github.com/livefront/bridge/pull/43, and https://github.com/livefront/bridge/pull/45. The `README` has been updated to give instructions on using `Bridge` for `View` objects.
