### PR TITLE
Don't ignore writing to disk on configuration changes

### DIFF
--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -141,7 +141,7 @@ class BridgeDelegate {
     }
 
     private boolean isAppInForeground() {
-        return mActivityCount > 0;
+        return mActivityCount > 0 || mIsConfigChange;
     }
 
     /**
@@ -150,15 +150,9 @@ class BridgeDelegate {
      * for this task (and any others currently running in the background) to complete before
      * proceeding in order to prevent the app from becoming fully "stopped" (and therefore killable
      * by the OS before the data is saved).
-     *
-     * Note that if there is a configuration change taking place, no action will be taken.
      */
     private void queueDiskWritingIfNecessary(@NonNull final String uuid,
                                              @NonNull final Bundle bundle) {
-        if (mIsConfigChange) {
-            // Don't process the Bundle or write it to disk during a config change
-            return;
-        }
         Runnable runnable = new Runnable() {
             @Override
             public void run() {


### PR DESCRIPTION
This PR fixes a subtle bug in which `onSaveInstanceState` might get called during a configuration change without a corresponding call to `onCreate` if a `Fragment` is backgrounded. This would result in a lack of data if you killed the app, returned, and then navigated back. Rather than declining to write data to disk during a configuration change, we'll treat it as the app being in the foreground...this way we still write on a background thread, so we still get the same performance improvement.