### PR TITLE
Add infinite backstack scenarios to the sample app

### DIFF
--- a/bridgesample/build.gradle
+++ b/bridgesample/build.gradle
@@ -11,6 +11,7 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -43,4 +44,10 @@ dependencies {
     implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
     implementation "com.android.support:design:$supportLibraryVersion"
     implementation "com.android.support:recyclerview-v7:$supportLibraryVersion"
+
+    androidTestImplementation 'com.android.support.test.uiautomator:uiautomator-v18:2.1.3'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.ext:junit-ktx:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/bridgesample/src/androidTest/java/com/livefront/bridgesample/scenario/activity/LargeDataActivityTest.kt
+++ b/bridgesample/src/androidTest/java/com/livefront/bridgesample/scenario/activity/LargeDataActivityTest.kt
@@ -1,0 +1,59 @@
+package com.livefront.bridgesample.scenario.activity
+
+import android.graphics.Bitmap
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Espresso.pressBack
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.platform.app.InstrumentationRegistry
+import com.livefront.bridgesample.R
+import com.livefront.bridgesample.util.getCurrentActivity
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LargeDataActivityTest {
+
+    @get:Rule
+    var activityScenarioRule = ActivityScenarioRule<LargeDataActivity>(
+            LargeDataActivity.getNavigationIntent(
+                    InstrumentationRegistry.getInstrumentation().targetContext,
+                    LargeDataActivityArguments(infiniteBackstack = false)
+            )
+    )
+
+    @Test
+    fun generateDataAndNavigateNoCrash() {
+        onView(withId(R.id.generateDataButton)).perform(click())
+        onView(withId(R.id.navigateButton)).perform(click())
+
+        // Wait 1 second to allow a crash to occur
+        Thread.sleep(1000)
+    }
+
+    @Test
+    fun generateDataAndNavigateCheckData() {
+        onView(withId(R.id.generateDataButton)).perform(click())
+
+        var originalBitmap: Bitmap?
+        (getCurrentActivity() as LargeDataActivity).apply {
+            originalBitmap = this.savedBitmap
+        }
+
+        onView(withId(R.id.navigateButton)).perform(click())
+
+        pressBack()
+
+        (getCurrentActivity() as LargeDataActivity).apply {
+            assertTrue(originalBitmap!!.sameAs(this.savedBitmap))
+        }
+
+        // Wait 1 second to allow a crash to occur
+        Thread.sleep(1000)
+    }
+}

--- a/bridgesample/src/androidTest/java/com/livefront/bridgesample/scenario/activity/LargeDataBackstackActivityTest.kt
+++ b/bridgesample/src/androidTest/java/com/livefront/bridgesample/scenario/activity/LargeDataBackstackActivityTest.kt
@@ -1,0 +1,95 @@
+package com.livefront.bridgesample.scenario.activity
+
+import android.graphics.Bitmap
+import android.support.test.uiautomator.UiDevice
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Espresso.pressBack
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.platform.app.InstrumentationRegistry
+import com.livefront.bridgesample.R
+import com.livefront.bridgesample.util.getCurrentActivity
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LargeDataBackstackActivityTest {
+
+    @get:Rule
+    var activityScenarioRule = ActivityScenarioRule<LargeDataActivity>(
+            LargeDataActivity.getNavigationIntent(
+                    InstrumentationRegistry.getInstrumentation().targetContext,
+                    LargeDataActivityArguments(infiniteBackstack = true)
+            )
+    )
+
+    @Test
+    fun generateDataAndNavigateForward() {
+        for (i in 1..5) {
+            onView(withId(R.id.generateDataButton)).perform(click())
+            onView(withId(R.id.navigateButton)).perform(click())
+        }
+
+        // Wait 1 second to allow a crash to occur
+        Thread.sleep(1000)
+    }
+
+    @Test
+    fun generateDataAndNavigateForwardAndBackward() {
+        onView(withId(R.id.generateDataButton)).perform(click())
+        var originalBitmap: Bitmap?
+        (getCurrentActivity() as LargeDataActivity).apply {
+            originalBitmap = this.savedBitmap
+        }
+        onView(withId(R.id.navigateButton)).perform(click())
+
+        for (i in 1 until 5) {
+            onView(withId(R.id.generateDataButton)).perform(click())
+            onView(withId(R.id.navigateButton)).perform(click())
+        }
+
+        for (i in 1..5) {
+            pressBack()
+        }
+
+        (getCurrentActivity() as LargeDataActivity).apply {
+            assertTrue(originalBitmap!!.sameAs(this.savedBitmap))
+        }
+
+        // Wait 1 second to allow a crash to occur
+        Thread.sleep(1000)
+    }
+
+    @Test
+    fun generateDataAndNavigateForwardRotateBackward() {
+        onView(withId(R.id.generateDataButton)).perform(click())
+        var originalBitmap: Bitmap? = null
+        (getCurrentActivity() as LargeDataActivity).apply {
+            originalBitmap = this.savedBitmap
+        }
+        onView(withId(R.id.navigateButton)).perform(click())
+
+        for (i in 1 until 5) {
+            onView(withId(R.id.generateDataButton)).perform(click())
+            onView(withId(R.id.navigateButton)).perform(click())
+        }
+
+        UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).setOrientationLeft()
+
+        for (i in 1..5) {
+            pressBack()
+        }
+
+        (getCurrentActivity() as LargeDataActivity).apply {
+            assertTrue(originalBitmap!!.sameAs(this.savedBitmap))
+        }
+
+        // Wait 1 second to allow a crash to occur
+        Thread.sleep(1000)
+    }
+}

--- a/bridgesample/src/androidTest/java/com/livefront/bridgesample/util/CurrentActivity.kt
+++ b/bridgesample/src/androidTest/java/com/livefront/bridgesample/util/CurrentActivity.kt
@@ -1,0 +1,23 @@
+package com.livefront.bridgesample.util
+
+import android.app.Activity
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
+import androidx.test.runner.lifecycle.Stage.RESUMED
+
+/**
+ * @return the current activity being displayed.
+ */
+fun getCurrentActivity(): Activity {
+    var currentActivity: Activity? = null
+
+    InstrumentationRegistry.getInstrumentation().runOnMainSync {
+        val resumedActivities = ActivityLifecycleMonitorRegistry.getInstance().getActivitiesInStage(
+                RESUMED
+        )
+        // This will throw an exception if there are no resumed activities.
+        currentActivity = resumedActivities.iterator().next()
+    }
+
+    return currentActivity!!
+}

--- a/bridgesample/src/main/java/com/livefront/bridgesample/main/model/Scenario.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/main/model/Scenario.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.scenario.activity.FragmentContainerActivity
 import com.livefront.bridgesample.scenario.activity.LargeDataActivity
+import com.livefront.bridgesample.scenario.activity.LargeDataActivityArguments
 import com.livefront.bridgesample.scenario.activity.NonBridgeLargeDataActivity
+import com.livefront.bridgesample.scenario.activity.NonBridgeLargeDataActivityArguments
 import com.livefront.bridgesample.scenario.activity.ViewContainerActivity
 import com.livefront.bridgesample.scenario.activity.ViewData
 import com.livefront.bridgesample.scenario.fragment.LargeDataFragment
@@ -19,12 +21,26 @@ fun getScenarios(context: Context): List<MainItem> = listOf(
         MainItem(
                 R.string.large_data_scenario_title,
                 R.string.large_data_scenario_description,
-                LargeDataActivity.getNavigationIntent(context)
+                LargeDataActivity.getNavigationIntent(context,
+                        LargeDataActivityArguments(infiniteBackstack = false))
         ),
         MainItem(
                 R.string.non_bridge_large_data_scenario_title,
                 R.string.non_bridge_large_data_scenario_description,
-                NonBridgeLargeDataActivity.getNavigationIntent(context)
+                NonBridgeLargeDataActivity.getNavigationIntent(context,
+                        NonBridgeLargeDataActivityArguments(infiniteBackstack = false))
+        ),
+        MainItem(
+                R.string.large_data_backstack_scenario_title,
+                R.string.large_data_backstack_scenario_description,
+                LargeDataActivity.getNavigationIntent(context,
+                        LargeDataActivityArguments(infiniteBackstack = true))
+        ),
+        MainItem(
+                R.string.non_bridge_large_data_backstack_scenario_title,
+                R.string.non_bridge_large_data_backstack_scenario_description,
+                NonBridgeLargeDataActivity.getNavigationIntent(context,
+                        NonBridgeLargeDataActivityArguments(infiniteBackstack = true))
         ),
         MainItem(
                 R.string.large_data_fragment_scenario_title,

--- a/bridgesample/src/main/java/com/livefront/bridgesample/main/model/Scenario.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/main/model/Scenario.kt
@@ -9,7 +9,9 @@ import com.livefront.bridgesample.scenario.activity.NonBridgeLargeDataActivity
 import com.livefront.bridgesample.scenario.activity.NonBridgeLargeDataActivityArguments
 import com.livefront.bridgesample.scenario.activity.ViewContainerActivity
 import com.livefront.bridgesample.scenario.activity.ViewData
+import com.livefront.bridgesample.scenario.fragment.LargeDataArguments
 import com.livefront.bridgesample.scenario.fragment.LargeDataFragment
+import com.livefront.bridgesample.scenario.fragment.NonBridgeLargeDataArguments
 import com.livefront.bridgesample.scenario.fragment.NonBridgeLargeDataFragment
 import com.livefront.bridgesample.scenario.fragment.StatePagerArguments
 import com.livefront.bridgesample.scenario.fragment.StatePagerFragment
@@ -56,6 +58,26 @@ fun getScenarios(context: Context): List<MainItem> = listOf(
                 FragmentContainerActivity.getNavigationIntent(
                         context,
                         NonBridgeLargeDataFragment.getFragmentData()
+                )
+        ),
+        MainItem(
+                R.string.large_data_fragment_backstack_scenario_title,
+                R.string.large_data_fragment_backstack_scenario_description,
+                FragmentContainerActivity.getNavigationIntent(
+                        context,
+                        LargeDataFragment.getFragmentData(
+                                LargeDataArguments(infiniteBackstack = true)
+                        )
+                )
+        ),
+        MainItem(
+                R.string.non_bridge_large_data_fragment_backstack_scenario_title,
+                R.string.non_bridge_large_data_fragment_backstack_scenario_description,
+                FragmentContainerActivity.getNavigationIntent(
+                        context,
+                        NonBridgeLargeDataFragment.getFragmentData(
+                                NonBridgeLargeDataArguments(infiniteBackstack = true)
+                        )
                 )
         ),
         MainItem(

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/FragmentContainerActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/FragmentContainerActivity.kt
@@ -11,6 +11,7 @@ import android.view.MenuItem
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.base.BridgeBaseActivity
 import com.livefront.bridgesample.scenario.activity.FragmentContainerActivity.Companion.getNavigationIntent
+import com.livefront.bridgesample.util.FragmentNavigationManager
 import com.livefront.bridgesample.util.handleHomeAsBack
 import com.livefront.bridgesample.util.setHomeAsUpToolbar
 import kotlinx.android.parcel.Parcelize
@@ -20,7 +21,7 @@ import kotlinx.android.synthetic.main.basic_toolbar.toolbar
  * A simple [Activity] with a container in which an initial [Fragment] may be placed. This is
  * done by supplying [FragmentData] via the [getNavigationIntent] method.
  */
-class FragmentContainerActivity : BridgeBaseActivity() {
+class FragmentContainerActivity : BridgeBaseActivity(), FragmentNavigationManager {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_fragment_container)
@@ -35,14 +36,21 @@ class FragmentContainerActivity : BridgeBaseActivity() {
                 data.fragmentClass.name,
                 data.fragmentBundle
         )
-        supportFragmentManager
-                .beginTransaction()
-                .replace(R.id.container, fragment)
-                .commit()
+        navigateTo(fragment, false)
     }
 
     override fun onOptionsItemSelected(item: MenuItem) = handleHomeAsBack(item) {
         super.onOptionsItemSelected(item)
+    }
+
+    override fun navigateTo(fragment: Fragment, addToBackstack: Boolean) {
+        supportFragmentManager
+                .beginTransaction()
+                .apply {
+                    replace(R.id.container, fragment)
+                    if (addToBackstack) addToBackStack(null)
+                }
+                .commit()
     }
 
     companion object {

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/LargeDataActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/LargeDataActivity.kt
@@ -4,12 +4,14 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
+import android.os.Parcelable
 import android.view.MenuItem
 import com.evernote.android.state.State
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.base.BridgeBaseActivity
 import com.livefront.bridgesample.util.handleHomeAsBack
 import com.livefront.bridgesample.util.setHomeAsUpToolbar
+import kotlinx.android.parcel.Parcelize
 import kotlinx.android.synthetic.main.activity_large_data.bitmapGeneratorView
 import kotlinx.android.synthetic.main.basic_toolbar.toolbar
 
@@ -26,6 +28,16 @@ class LargeDataActivity : BridgeBaseActivity() {
             setHeaderText(R.string.large_data_header)
             generatedBitmap = savedBitmap
             onBitmapGeneratedListener = { savedBitmap = it }
+            if (getArguments(this@LargeDataActivity).infiniteBackstack) {
+                onNavigateButtonClickListener = {
+                    startActivity(
+                            getNavigationIntent(
+                                    this@LargeDataActivity,
+                                    getArguments(this@LargeDataActivity)
+                            )
+                    )
+                }
+            }
         }
     }
 
@@ -34,9 +46,24 @@ class LargeDataActivity : BridgeBaseActivity() {
     }
 
     companion object {
-        fun getNavigationIntent(context: Context) = Intent(
-                context,
-                LargeDataActivity::class.java
-        )
+        private const val ARGUMENTS_KEY = "arguments"
+
+        fun getArguments(
+            activity: LargeDataActivity
+        ): LargeDataActivityArguments = activity
+                .intent
+                .getParcelableExtra(ARGUMENTS_KEY)
+
+        fun getNavigationIntent(
+            context: Context,
+            arguments: LargeDataActivityArguments
+        ) = Intent(context, LargeDataActivity::class.java).apply {
+            putExtra(ARGUMENTS_KEY, arguments)
+        }
     }
 }
+
+@Parcelize
+data class LargeDataActivityArguments(
+    val infiniteBackstack: Boolean = false
+) : Parcelable

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/NonBridgeLargeDataActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/NonBridgeLargeDataActivity.kt
@@ -4,12 +4,14 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
+import android.os.Parcelable
 import android.view.MenuItem
 import com.evernote.android.state.State
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.base.NonBridgeBaseActivity
 import com.livefront.bridgesample.util.handleHomeAsBack
 import com.livefront.bridgesample.util.setHomeAsUpToolbar
+import kotlinx.android.parcel.Parcelize
 import kotlinx.android.synthetic.main.activity_large_data.bitmapGeneratorView
 import kotlinx.android.synthetic.main.basic_toolbar.toolbar
 
@@ -26,6 +28,16 @@ class NonBridgeLargeDataActivity : NonBridgeBaseActivity() {
             setHeaderText(R.string.non_bridge_large_data_header)
             generatedBitmap = savedBitmap
             onBitmapGeneratedListener = { savedBitmap = it }
+            if (getArguments(this@NonBridgeLargeDataActivity).infiniteBackstack) {
+                onNavigateButtonClickListener = {
+                    startActivity(
+                            getNavigationIntent(
+                                    this@NonBridgeLargeDataActivity,
+                                    getArguments(this@NonBridgeLargeDataActivity)
+                            )
+                    )
+                }
+            }
         }
     }
 
@@ -34,9 +46,25 @@ class NonBridgeLargeDataActivity : NonBridgeBaseActivity() {
     }
 
     companion object {
-        fun getNavigationIntent(context: Context) = Intent(
-                context,
-                NonBridgeLargeDataActivity::class.java
-        )
+        private const val ARGUMENTS_KEY = "arguments"
+
+        fun getArguments(
+            activity: NonBridgeLargeDataActivity
+        ): NonBridgeLargeDataActivityArguments = activity
+                .intent
+                .getParcelableExtra(ARGUMENTS_KEY)
+
+
+        fun getNavigationIntent(
+            context: Context,
+            arguments: NonBridgeLargeDataActivityArguments
+        ) = Intent(context, NonBridgeLargeDataActivity::class.java).apply {
+            putExtra(ARGUMENTS_KEY, arguments)
+        }
     }
 }
+
+@Parcelize
+data class NonBridgeLargeDataActivityArguments(
+    val infiniteBackstack: Boolean = false
+) : Parcelable

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/LargeDataFragment.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/LargeDataFragment.kt
@@ -1,5 +1,6 @@
 package com.livefront.bridgesample.scenario.fragment
 
+import android.content.Context
 import android.graphics.Bitmap
 import android.os.Bundle
 import android.os.Parcelable
@@ -10,6 +11,7 @@ import com.evernote.android.state.State
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.base.BridgeBaseFragment
 import com.livefront.bridgesample.scenario.activity.FragmentData
+import com.livefront.bridgesample.util.FragmentNavigationManager
 import kotlinx.android.parcel.Parcelize
 import kotlinx.android.synthetic.main.activity_large_data.bitmapGeneratorView
 
@@ -19,6 +21,13 @@ class LargeDataFragment : BridgeBaseFragment() {
 
     @State
     var savedBitmap: Bitmap? = null
+
+    private lateinit var fragmentNavigationManager: FragmentNavigationManager
+
+    override fun onAttach(context: Context?) {
+        super.onAttach(context)
+        fragmentNavigationManager = context as FragmentNavigationManager
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -31,6 +40,19 @@ class LargeDataFragment : BridgeBaseFragment() {
             setHeaderText(R.string.large_data_header)
             generatedBitmap = savedBitmap
             onBitmapGeneratedListener = { savedBitmap = it }
+            if (getArguments(this@LargeDataFragment).infiniteBackstack) {
+                onNavigateButtonClickListener = {
+                    fragmentNavigationManager.navigateTo(
+                            newInstance(
+                                    LargeDataArguments(
+                                            getArguments(this@LargeDataFragment).shouldClearOnDestroy,
+                                            infiniteBackstack = true
+                                    )
+                            ),
+                            addToBackstack = true
+                    )
+                }
+            }
         }
     }
 
@@ -67,5 +89,6 @@ class LargeDataFragment : BridgeBaseFragment() {
 
 @Parcelize
 data class LargeDataArguments(
-    val shouldClearOnDestroy: Boolean = true
+    val shouldClearOnDestroy: Boolean = true,
+    val infiniteBackstack: Boolean = false
 ) : Parcelable

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/NonBridgeLargeDataFragment.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/NonBridgeLargeDataFragment.kt
@@ -1,7 +1,9 @@
 package com.livefront.bridgesample.scenario.fragment
 
+import android.content.Context
 import android.graphics.Bitmap
 import android.os.Bundle
+import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -9,11 +11,20 @@ import com.evernote.android.state.State
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.base.NonBridgeBaseFragment
 import com.livefront.bridgesample.scenario.activity.FragmentData
+import com.livefront.bridgesample.util.FragmentNavigationManager
+import kotlinx.android.parcel.Parcelize
 import kotlinx.android.synthetic.main.activity_large_data.bitmapGeneratorView
 
 class NonBridgeLargeDataFragment : NonBridgeBaseFragment() {
     @State
     var savedBitmap: Bitmap? = null
+
+    private lateinit var fragmentNavigationManager: FragmentNavigationManager
+
+    override fun onAttach(context: Context?) {
+        super.onAttach(context)
+        fragmentNavigationManager = context as FragmentNavigationManager
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -26,20 +37,51 @@ class NonBridgeLargeDataFragment : NonBridgeBaseFragment() {
             setHeaderText(R.string.non_bridge_large_data_header)
             generatedBitmap = savedBitmap
             onBitmapGeneratedListener = { savedBitmap = it }
+            if (getArguments(this@NonBridgeLargeDataFragment).infiniteBackstack) {
+                onNavigateButtonClickListener = {
+                    fragmentNavigationManager.navigateTo(
+                            newInstance(
+                                    NonBridgeLargeDataArguments(infiniteBackstack = true)
+                            ),
+                            addToBackstack = true
+                    )
+                }
+            }
         }
     }
 
     companion object {
-        fun getFragmentData() = FragmentData(
+        private const val ARGUMENTS_KEY = "arguments"
+
+        fun getArguments(
+            fragment: NonBridgeLargeDataFragment
+        ): NonBridgeLargeDataArguments = fragment
+                .arguments!!
+                .getParcelable(ARGUMENTS_KEY)
+
+        fun getFragmentData(
+            nonBridgeLargeDataArguments: NonBridgeLargeDataArguments = NonBridgeLargeDataArguments()
+        ) = FragmentData(
                 R.string.non_bridge_large_data_screen_title,
                 NonBridgeLargeDataFragment::class.java,
-                getInitialArguments()
+                getInitialArguments(nonBridgeLargeDataArguments)
         )
 
-        fun getInitialArguments() = Bundle()
+        fun getInitialArguments(
+            nonBridgeLargeDataArguments: NonBridgeLargeDataArguments = NonBridgeLargeDataArguments()
+        ) = Bundle().apply {
+            putParcelable(ARGUMENTS_KEY, nonBridgeLargeDataArguments)
+        }
 
-        fun newInstance() = NonBridgeLargeDataFragment().apply {
-            arguments = getInitialArguments()
+        fun newInstance(
+            nonBridgeLargeDataArguments: NonBridgeLargeDataArguments = NonBridgeLargeDataArguments()
+        ) = NonBridgeLargeDataFragment().apply {
+            arguments = getInitialArguments(nonBridgeLargeDataArguments)
         }
     }
 }
+
+@Parcelize
+data class NonBridgeLargeDataArguments(
+    val infiniteBackstack: Boolean = false
+) : Parcelable

--- a/bridgesample/src/main/java/com/livefront/bridgesample/util/FragmentNavigationManager.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/util/FragmentNavigationManager.kt
@@ -1,0 +1,13 @@
+package com.livefront.bridgesample.util
+
+import android.support.v4.app.Fragment
+
+/**
+ * Helper interface to provide fragment navigation.
+ */
+interface FragmentNavigationManager {
+    /**
+     * Navigates to the specified fragment, adding it to the backstack if requested.
+     */
+    fun navigateTo(fragment: Fragment, addToBackstack: Boolean)
+}

--- a/bridgesample/src/main/res/values/strings.xml
+++ b/bridgesample/src/main/res/values/strings.xml
@@ -13,12 +13,16 @@
     <string name="large_data_fragment_scenario_title">Fragment with Large Data</string>
     <string name="large_data_scenario_description">with Bridge</string>
     <string name="large_data_scenario_title">Activity with Large Data</string>
+    <string name="large_data_backstack_scenario_title">Activity with Large Data and Backstack</string>
+    <string name="large_data_backstack_scenario_description">with Bridge</string>
     <string name="large_data_view_scenario_description">with Bridge</string>
     <string name="large_data_view_scenario_title">View with Large Data</string>
     <string name="non_bridge_large_data_fragment_scenario_title">Fragment with Large Data</string>
     <string name="non_bridge_large_data_fragment_scenario_description">without Bridge</string>
     <string name="non_bridge_large_data_scenario_description">without Bridge</string>
     <string name="non_bridge_large_data_scenario_title">Activity with Large Data</string>
+    <string name="non_bridge_large_data_backstack_scenario_title">Activity with Large Data and Backstack</string>
+    <string name="non_bridge_large_data_backstack_scenario_description">without Bridge</string>
     <string name="non_bridge_large_data_view_scenario_description">without Bridge</string>
     <string name="non_bridge_large_data_view_scenario_title">View with Large Data</string>
     <string name="non_bridge_state_pager_scenario_description">without Bridge</string>

--- a/bridgesample/src/main/res/values/strings.xml
+++ b/bridgesample/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <!-- Scenarios -->
     <string name="large_data_fragment_scenario_description">with Bridge</string>
     <string name="large_data_fragment_scenario_title">Fragment with Large Data</string>
+    <string name="large_data_fragment_backstack_scenario_description">with Bridge</string>
+    <string name="large_data_fragment_backstack_scenario_title">Fragment with Large Data and Backstack</string>
     <string name="large_data_scenario_description">with Bridge</string>
     <string name="large_data_scenario_title">Activity with Large Data</string>
     <string name="large_data_backstack_scenario_title">Activity with Large Data and Backstack</string>
@@ -19,6 +21,8 @@
     <string name="large_data_view_scenario_title">View with Large Data</string>
     <string name="non_bridge_large_data_fragment_scenario_title">Fragment with Large Data</string>
     <string name="non_bridge_large_data_fragment_scenario_description">without Bridge</string>
+    <string name="non_bridge_large_data_fragment_backstack_scenario_title">Fragment with Large Data and Backstack</string>
+    <string name="non_bridge_large_data_fragment_backstack_scenario_description">without Bridge</string>
     <string name="non_bridge_large_data_scenario_description">without Bridge</string>
     <string name="non_bridge_large_data_scenario_title">Activity with Large Data</string>
     <string name="non_bridge_large_data_backstack_scenario_title">Activity with Large Data and Backstack</string>


### PR DESCRIPTION
This PR adds two scenarios to the bridgesample app, allowing for an arbitrary number of fragments/activities to be added to the backstack with large amounts of data. This will help for manual testing for bugs such as #45.

Some basic Espresso tests were also added to the sample app.