### PR TITLE
Fix restore edge case when app is recycled and open from deeplink

### DIFF
--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -146,6 +146,14 @@ class BridgeDelegate {
     }
 
     /**
+     * When the app is recycled background and bring up by deeplink, we shouldn't clear the data.
+     */
+    private boolean openedFromDeeplink(@NonNull Activity activity) {
+        return Intent.ACTION_VIEW.equals(activity.getIntent().getAction())
+                && activity.getIntent().getData() != null;
+    }
+
+    /**
      * When the app is foregrounded, the given Bundle will be processed on a background thread and
      * then persisted to disk. When the app is proceeding to the background, this method will wait
      * for this task (and any others currently running in the background) to complete before
@@ -204,11 +212,12 @@ class BridgeDelegate {
                 new ActivityLifecycleCallbacksAdapter() {
                     @Override
                     public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+                        mIsClearAllowed = true;
+                        mIsConfigChange = false;
+
                         if (openedFromDeeplink(activity)) {
                             return;
                         }
-                        mIsClearAllowed = true;
-                        mIsConfigChange = false;
 
                         // Make sure we clear all data after creating the first Activity if it does
                         // does not have a saved stated Bundle. (During state restoration, the
@@ -345,8 +354,4 @@ class BridgeDelegate {
                 .apply();
     }
 
-    private boolean openedFromDeeplink(Activity activity) {
-        return Intent.ACTION_VIEW.equals(activity.getIntent().getAction())
-                && activity.getIntent().getData() != null;
-    }
 }

--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Parcelable;
@@ -203,6 +204,9 @@ class BridgeDelegate {
                 new ActivityLifecycleCallbacksAdapter() {
                     @Override
                     public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+                        if (openedFromDeeplink(activity)) {
+                            return;
+                        }
                         mIsClearAllowed = true;
                         mIsConfigChange = false;
 
@@ -341,4 +345,8 @@ class BridgeDelegate {
                 .apply();
     }
 
+    private boolean openedFromDeeplink(Activity activity) {
+        return Intent.ACTION_VIEW.equals(activity.getIntent().getAction())
+                && activity.getIntent().getData() != null;
+    }
 }

--- a/bridgesample/src/main/AndroidManifest.xml
+++ b/bridgesample/src/main/AndroidManifest.xml
@@ -28,13 +28,49 @@
 
         <activity android:name=".scenario.activity.FragmentContainerActivity" />
 
-        <activity android:name=".scenario.activity.LargeDataActivity" />
+        <activity android:name=".scenario.activity.LargeDataActivity"
+            android:launchMode="singleTask">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:pathPattern="/large-activity"
+                    android:host="www.android-bridge.com"
+                    android:scheme="http" />
+            </intent-filter>
+        </activity>
 
         <activity android:name=".scenario.activity.NonBridgeLargeDataActivity" />
 
-        <activity android:name=".scenario.activity.SuccessActivity" />
+        <activity android:name=".scenario.activity.SuccessActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:pathPattern="/success-activity"
+                    android:host="www.android-bridge.com"
+                    android:scheme="http" />
+            </intent-filter>
+        </activity>
 
         <activity android:name=".scenario.activity.ViewContainerActivity" />
+
+        <activity android:name=".scenario.activity.DeeplinkActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:pathPattern="/deeplink-activity"
+                    android:host="www.android-bridge.com"
+                    android:scheme="http" />
+            </intent-filter>
+        </activity>
 
     </application>
 

--- a/bridgesample/src/main/AndroidManifest.xml
+++ b/bridgesample/src/main/AndroidManifest.xml
@@ -28,7 +28,9 @@
 
         <activity android:name=".scenario.activity.FragmentContainerActivity" />
 
-        <activity android:name=".scenario.activity.LargeDataActivity"
+        <activity android:name=".scenario.activity.LargeDataActivity" />
+
+        <activity android:name=".scenario.activity.DeeplinkLargeDataActivity"
             android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/DeeplinkActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/DeeplinkActivity.kt
@@ -1,0 +1,19 @@
+package com.livefront.bridgesample.scenario.activity
+
+import android.content.Intent
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+
+class DeeplinkActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        startActivity(LargeDataActivity.getNavigationIntent(this,
+                LargeDataActivityArguments(infiniteBackstack = false)).apply {
+            addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
+        })
+        finish()
+    }
+}

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/DeeplinkActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/DeeplinkActivity.kt
@@ -7,13 +7,16 @@ import android.support.v7.app.AppCompatActivity
 class DeeplinkActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        startActivity(LargeDataActivity.getNavigationIntent(this,
-                LargeDataActivityArguments(infiniteBackstack = false)).apply {
-            addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
-            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
-        })
+        startActivity(
+                LargeDataActivity.getNavigationIntent(
+                        this,
+                        LargeDataActivityArguments(infiniteBackstack = false)).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                    addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
+                }
+        )
         finish()
     }
 }

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/DeeplinkLargeDataActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/DeeplinkLargeDataActivity.kt
@@ -4,18 +4,16 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
-import android.os.Parcelable
 import android.view.MenuItem
 import com.evernote.android.state.State
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.base.BridgeBaseActivity
 import com.livefront.bridgesample.util.handleHomeAsBack
 import com.livefront.bridgesample.util.setHomeAsUpToolbar
-import kotlinx.android.parcel.Parcelize
 import kotlinx.android.synthetic.main.activity_large_data.bitmapGeneratorView
 import kotlinx.android.synthetic.main.basic_toolbar.toolbar
 
-class LargeDataActivity : BridgeBaseActivity() {
+class DeeplinkLargeDataActivity : BridgeBaseActivity() {
     @State
     var savedBitmap: Bitmap? = null
 
@@ -28,12 +26,12 @@ class LargeDataActivity : BridgeBaseActivity() {
             setHeaderText(R.string.large_data_header)
             generatedBitmap = savedBitmap
             onBitmapGeneratedListener = { savedBitmap = it }
-            if (getArguments(this@LargeDataActivity).infiniteBackstack) {
+            if (getArguments(this@DeeplinkLargeDataActivity)?.infiniteBackstack == true) {
                 onNavigateButtonClickListener = {
                     startActivity(
                             getNavigationIntent(
-                                    this@LargeDataActivity,
-                                    getArguments(this@LargeDataActivity)
+                                    this@DeeplinkLargeDataActivity,
+                                    getArguments(this@DeeplinkLargeDataActivity)
                             )
                     )
                 }
@@ -49,21 +47,16 @@ class LargeDataActivity : BridgeBaseActivity() {
         private const val ARGUMENTS_KEY = "arguments"
 
         fun getArguments(
-                activity: LargeDataActivity
-        ): LargeDataActivityArguments = activity
+            activity: DeeplinkLargeDataActivity
+        ): LargeDataActivityArguments? = activity
                 .intent
                 .getParcelableExtra(ARGUMENTS_KEY)
 
         fun getNavigationIntent(
-                context: Context,
-                arguments: LargeDataActivityArguments
+            context: Context,
+            arguments: LargeDataActivityArguments?
         ) = Intent(context, LargeDataActivity::class.java).apply {
             putExtra(ARGUMENTS_KEY, arguments)
         }
     }
 }
-
-@Parcelize
-data class LargeDataActivityArguments(
-        val infiniteBackstack: Boolean = false
-) : Parcelable

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/LargeDataActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/LargeDataActivity.kt
@@ -28,7 +28,7 @@ class LargeDataActivity : BridgeBaseActivity() {
             setHeaderText(R.string.large_data_header)
             generatedBitmap = savedBitmap
             onBitmapGeneratedListener = { savedBitmap = it }
-            if (getArguments(this@LargeDataActivity).infiniteBackstack) {
+            if (getArguments(this@LargeDataActivity)?.infiniteBackstack == true) {
                 onNavigateButtonClickListener = {
                     startActivity(
                             getNavigationIntent(
@@ -50,13 +50,13 @@ class LargeDataActivity : BridgeBaseActivity() {
 
         fun getArguments(
             activity: LargeDataActivity
-        ): LargeDataActivityArguments = activity
+        ): LargeDataActivityArguments? = activity
                 .intent
                 .getParcelableExtra(ARGUMENTS_KEY)
 
         fun getNavigationIntent(
             context: Context,
-            arguments: LargeDataActivityArguments
+            arguments: LargeDataActivityArguments?
         ) = Intent(context, LargeDataActivity::class.java).apply {
             putExtra(ARGUMENTS_KEY, arguments)
         }


### PR DESCRIPTION
Hi, team.

There is an edge scenario that state gets cleared when app is opened from deeplink after app is recycled.

So the fix is simple, we need to exclude triggered by deeplink.

And I also created test environment for this.

Most app will have a splash activity or deeplink activity to handle deeplink specificly, or deeplink open a new activity which will be above the old recycled one, the restore will also fail.

Test:

- Have standalone DeeplinkActivity to dispatch.

1. Open sample and go to LargeDataWithBridge activity, click generate.
2. Back home the app, and kill it in AndroidStudio (There is a terminate button in the bottom of  `Logcat` sidebar).
3. `adb shell am start -W -a android.intent.action.VIEW -d "http://www.android-bridge.com/deeplink-activity"`

State should be restored.

- LargeDataActivity is the one handle deeplink (mainly our main activity will be singleTask, otherwise it is like the 3rd scenario because it will be freshly opened)

1. Open sample and go to LargeDataWithBridge activity, click generate.
2. Back home the app, and kill it in AndroidStudio (There is a terminate button in the bottom of  `Logcat` sidebar).
3. `adb shell am start -W -a android.intent.action.VIEW -d "http://www.android-bridge.com/large-activity"`

State should be restored.

- Deeplink to open a new activity above

1. Open sample and go to LargeDataWithBridge activity, click generate.
2. Back home the app, and kill it in AndroidStudio (There is a terminate button in the bottom of  `Logcat` sidebar).
3. `adb shell am start -W -a android.intent.action.VIEW -d "http://www.android-bridge.com/success-activity"`
4. Click back button

State should be restored.

**The side effect is the state can not get cleared for the second scenario when app is not recycled, but it can be cleared during the next activity launch**