### PR TITLE
Make clear robust for edge case, like restore and then deeplink call up

### DIFF
--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -2,9 +2,11 @@ package com.livefront.bridge;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.app.ActivityManager;
 import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
@@ -145,6 +147,27 @@ class BridgeDelegate {
     }
 
     /**
+     * If it's a fresh start, we can safely clear cache
+     */
+    private boolean isFreshStart(@NonNull Activity activity, @NonNull Bundle savedInstanceState) {
+        if (!mIsFirstCreateCall) {
+            return false;
+        }
+        mIsFirstCreateCall = false;
+        if (savedInstanceState != null) {
+            return false;
+        }
+        ActivityManager activityManager = (ActivityManager) activity.getSystemService(Context.ACTIVITY_SERVICE);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            List<ActivityManager.AppTask> appTasks = activityManager.getAppTasks();
+            return appTasks.size() == 1 && appTasks.get(0).getTaskInfo().numActivities == 1;
+        } else {
+            List<ActivityManager.RunningTaskInfo> runningTasks = activityManager.getRunningTasks(1);
+            return runningTasks.size() == 1 && runningTasks.get(0).numActivities == 1;
+        }
+    }
+
+    /**
      * When the app is foregrounded, the given Bundle will be processed on a background thread and
      * then persisted to disk. When the app is proceeding to the background, this method will wait
      * for this task (and any others currently running in the background) to complete before
@@ -208,16 +231,15 @@ class BridgeDelegate {
 
                         // Make sure we clear all data after creating the first Activity if it does
                         // does not have a saved stated Bundle. (During state restoration, the
-                        // first Activity will always have a non-null saved state Bundle.)
-                        if (!mIsFirstCreateCall) {
+                        // first Activity will always have a non-null saved state Bundle, edge case for
+                        // deeplink call up, it will be non-null for new deeplink activity.)
+                        if (!isFreshStart(activity, savedInstanceState)) {
                             return;
                         }
-                        mIsFirstCreateCall = false;
-                        if (savedInstanceState == null) {
-                            mSharedPreferences.edit()
-                                    .clear()
-                                    .apply();
-                        }
+
+                        mSharedPreferences.edit()
+                                .clear()
+                                .apply();
                     }
 
                     @Override

--- a/bridgesample/src/main/AndroidManifest.xml
+++ b/bridgesample/src/main/AndroidManifest.xml
@@ -30,11 +30,46 @@
 
         <activity android:name=".scenario.activity.LargeDataActivity" />
 
+        <activity android:name=".scenario.activity.DeeplinkLargeDataActivity"
+            android:launchMode="singleTask">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="large-data-activity"
+                    android:scheme="http" />
+            </intent-filter>
+        </activity>
+
         <activity android:name=".scenario.activity.NonBridgeLargeDataActivity" />
 
-        <activity android:name=".scenario.activity.SuccessActivity" />
+        <activity android:name=".scenario.activity.SuccessActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="success-activity"
+                    android:scheme="http" />
+            </intent-filter>
+        </activity>
 
         <activity android:name=".scenario.activity.ViewContainerActivity" />
+
+        <activity android:name=".scenario.activity.DeeplinkActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="deeplink-activity"
+                    android:scheme="http" />
+            </intent-filter>
+        </activity>
 
     </application>
 

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/DeeplinkActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/DeeplinkActivity.kt
@@ -1,0 +1,22 @@
+package com.livefront.bridgesample.scenario.activity
+
+import android.content.Intent
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+
+class DeeplinkActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        startActivity(
+                LargeDataActivity.getNavigationIntent(
+                        this,
+                        LargeDataActivityArguments(infiniteBackstack = false)).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                    addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
+                }
+        )
+        finish()
+    }
+}

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/DeeplinkLargeDataActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/DeeplinkLargeDataActivity.kt
@@ -1,0 +1,63 @@
+package com.livefront.bridgesample.scenario.activity
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.os.Bundle
+import android.view.MenuItem
+import com.evernote.android.state.State
+import com.livefront.bridgesample.R
+import com.livefront.bridgesample.base.BridgeBaseActivity
+import com.livefront.bridgesample.util.handleHomeAsBack
+import com.livefront.bridgesample.util.setHomeAsUpToolbar
+import kotlinx.android.synthetic.main.activity_large_data.bitmapGeneratorView
+import kotlinx.android.synthetic.main.basic_toolbar.toolbar
+
+class DeeplinkLargeDataActivity : BridgeBaseActivity() {
+    @State
+    var savedBitmap: Bitmap? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_large_data)
+        setHomeAsUpToolbar(toolbar, R.string.large_data_screen_title)
+
+        bitmapGeneratorView.apply {
+            setHeaderText(R.string.large_data_header)
+            generatedBitmap = savedBitmap
+            onBitmapGeneratedListener = { savedBitmap = it }
+            if (getArguments(this@DeeplinkLargeDataActivity).infiniteBackstack) {
+                onNavigateButtonClickListener = {
+                    startActivity(
+                            LargeDataActivity.getNavigationIntent(
+                                    this@DeeplinkLargeDataActivity,
+                                    getArguments(this@DeeplinkLargeDataActivity)
+                            )
+                    )
+                }
+            }
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem) = handleHomeAsBack(item) {
+        super.onOptionsItemSelected(item)
+    }
+
+    companion object {
+        private const val ARGUMENTS_KEY = "arguments"
+
+        fun getArguments(
+            activity: DeeplinkLargeDataActivity
+        ): LargeDataActivityArguments = activity
+                .intent
+                .getParcelableExtra(ARGUMENTS_KEY)
+                ?: LargeDataActivityArguments()
+
+        fun getNavigationIntent(
+            context: Context,
+            arguments: LargeDataActivityArguments
+        ) = Intent(context, LargeDataActivity::class.java).apply {
+            putExtra(ARGUMENTS_KEY, arguments)
+        }
+    }
+}


### PR DESCRIPTION
I am trying to use task check to make sure we only clear cache for fresh start and back to main.

If there is only one task and one activity which means that we are in a state of fresh launch or back to last activity, if there is no save instance, we can safely clear.

We can still use these test cases to do the test.

Test scenario:

- Have standalone DeeplinkActivity to dispatch.

1. Open sample and go to LargeDataWithBridge activity, click generate.
2. Back home the app, and kill it in AndroidStudio (There is a terminate button in the bottom of  `Logcat` sidebar).
3. `adb shell am start -W -a android.intent.action.VIEW -d "http://deeplink-activity"`

State should be restored.

- LargeDataActivity is the one handle deeplink (mainly our main activity will be singleTask, otherwise it is like the 3rd scenario because it will be freshly opened)

1. Open sample and go to LargeDataWithBridge activity, click generate.
2. Back home the app, and kill it in AndroidStudio (There is a terminate button in the bottom of  `Logcat` sidebar).
3. `adb shell am start -W -a android.intent.action.VIEW -d "http://large-data-activity"`

State should be restored.

- Deeplink to open a new activity above

1. Open sample and go to LargeDataWithBridge activity, click generate.
2. Back home the app, and kill it in AndroidStudio (There is a terminate button in the bottom of  `Logcat` sidebar).
3. `adb shell am start -W -a android.intent.action.VIEW -d "http://success-activity"`
4. Click back button

State should be restored.

**The side effect is the state can not get cleared for the second scenario when app is not recycled, but it can be cleared during the next activity launch**