### PR TITLE
Fix rotation clearing race condition

### DIFF
--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -174,7 +174,7 @@ class BridgeDelegate {
                 }
             }
         };
-        if (mPendingWriteTasksLatch == null) {
+        if (mPendingWriteTasksLatch == null || mPendingWriteTasksLatch.getCount() == 0) {
             mPendingWriteTasksLatch = new CountDownLatch(1);
         }
         mPendingWriteTasks.add(runnable);

--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -14,11 +14,11 @@ import android.view.View;
 import com.livefront.bridge.util.BundleUtil;
 import com.livefront.bridge.wrapper.WrapperUtils;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -47,7 +47,7 @@ class BridgeDelegate {
     private volatile CountDownLatch mPendingWriteTasksLatch = null;
     private ExecutorService mExecutorService = Executors.newCachedThreadPool();
     private List<Runnable> mPendingWriteTasks = new CopyOnWriteArrayList<>();
-    private Map<String, Bundle> mUuidBundleMap = new HashMap<>();
+    private Map<String, Bundle> mUuidBundleMap = new ConcurrentHashMap<>();
     private Map<Object, String> mObjectUuidMap = new WeakHashMap<>();
     private SavedStateHandler mSavedStateHandler;
     private SharedPreferences mSharedPreferences;
@@ -158,6 +158,12 @@ class BridgeDelegate {
             public void run() {
                 // Process the Parcel and write the data to disk
                 writeToDisk(uuid, bundle);
+
+                if (!mUuidBundleMap.containsKey(uuid)) {
+                    // While we were processing the data in the background, it was deleted from
+                    // memory. We should simply delete the data persisted to disk now as well.
+                    clearDataFromDisk(uuid);
+                }
 
                 // Remove this Runnable from the pending list
                 mPendingWriteTasks.remove(this);


### PR DESCRIPTION
This PR fixes two minor issues that are both related to configuration changes:

- Right now when you rotate the device, the `Bundle` will be immediately stored in memory and then written to disk in the background. Once that data is read again with `Bridge.restoreInstanceState`, we clear the data since it has been consumed and is no longer necessary. The bug is that sometimes that background process finishes _after_ this data clearing happens. In order to detect that the data should have been cleared, we now check to see if the data was removed from memory already (via `mUuidBundleMap.containsKey(uuid)`) and we delete the data we just wrote to disk if it should have been cleared. 
  
    Note that in an early MR I originally tried to simply avoid writing to disk for configuration changes, but it turns out that in some edge cases `saveInstanceState` will be called during a configuration change without a corresponding immediate call to `restoreInstanceState`, so we still need to write to disk in these cases.

- After fixing the first issue here, a concurrency issue surfaced : if you do a configuration change and then immediately background the app, the `CountDownLatch` that is supposed to keep the UI process running until all data has been written to disk can sometimes appear to count down too early. What is happening is that `mPendingWriteTasksLatch.countDown()` is called as a result of the processing completing for the rotation and before `mPendingWriteTasksLatch` can be nulled out on the main thread as a result of `queueDiskWritingIfNecessary` completing,  `queueDiskWritingIfNecessary` is already being called again. Then we hit this code:
    ```java
        if (mPendingWriteTasksLatch == null) {
            mPendingWriteTasksLatch = new CountDownLatch(1);
        }
    ```
    `mPendingWriteTasksLatch` _should_ be `null` already and we _should_ create a new latch, but it isn't and we don't. ~~The fix is to null out `mPendingWriteTasksLatch` immediately after `mPendingWriteTasksLatch.countDown()` is called (in addition to the end of the `queueDiskWritingIfNecessary` method itself).~~ The fix is to see if the latch has already counted down and, if so, to act as if the latch were null:
    ```java
        if (mPendingWriteTasksLatch == null || mPendingWriteTasksLatch.getCount() == 0) {
            mPendingWriteTasksLatch = new CountDownLatch(1);
        }
    ```