### PR TITLE
Internal sample ui polish

### DIFF
--- a/bridgesample/src/main/java/com/livefront/bridgesample/main/activity/MainActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/main/activity/MainActivity.kt
@@ -6,7 +6,7 @@ import com.livefront.bridgesample.base.BridgeBaseActivity
 import com.livefront.bridgesample.main.adapter.MainAdapter
 import com.livefront.bridgesample.main.model.getScenarios
 import kotlinx.android.synthetic.main.activity_main.recyclerView
-import kotlinx.android.synthetic.main.activity_main.toolbar
+import kotlinx.android.synthetic.main.basic_toolbar.toolbar
 
 class MainActivity : BridgeBaseActivity() {
     private lateinit var mainAdapter: MainAdapter

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/FragmentContainerActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/FragmentContainerActivity.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.support.annotation.StringRes
 import android.support.v4.app.Fragment
+import android.support.v4.app.FragmentTransaction
 import android.view.MenuItem
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.base.BridgeBaseActivity
@@ -46,6 +47,7 @@ class FragmentContainerActivity : BridgeBaseActivity(), FragmentNavigationManage
     override fun navigateTo(fragment: Fragment, addToBackstack: Boolean) {
         supportFragmentManager
                 .beginTransaction()
+                .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
                 .apply {
                     replace(R.id.container, fragment)
                     if (addToBackstack) addToBackStack(null)

--- a/bridgesample/src/main/res/layout/activity_main.xml
+++ b/bridgesample/src/main/res/layout/activity_main.xml
@@ -9,13 +9,11 @@
     android:orientation="vertical"
     tools:context=".main.activity.MainActivity">
 
-    <android.support.v7.widget.Toolbar
+    <include
         android:id="@+id/toolbar"
+        layout="@layout/basic_toolbar"
         android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:background="@color/colorPrimary"
-        android:theme="@style/AppTheme.ToolbarOverlay"
-        app:popupTheme="@style/AppTheme.PopupOverlay" />
+        android:layout_height="wrap_content"/>
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/recyclerView"

--- a/bridgesample/src/main/res/layout/basic_toolbar.xml
+++ b/bridgesample/src/main/res/layout/basic_toolbar.xml
@@ -6,5 +6,6 @@
     android:layout_width="match_parent"
     android:layout_height="?attr/actionBarSize"
     android:background="@color/colorPrimary"
+    android:elevation="@dimen/toolbar_elevation"
     android:theme="@style/AppTheme.ToolbarOverlay"
     app:popupTheme="@style/AppTheme.PopupOverlay" />

--- a/bridgesample/src/main/res/values/dimens.xml
+++ b/bridgesample/src/main/res/values/dimens.xml
@@ -3,6 +3,7 @@
     <dimen name="default_margin">16dp</dimen>
     <dimen name="min_button_height">48dp</dimen>
     <dimen name="test_image_size">250dp</dimen>
+    <dimen name="toolbar_elevation">8dp</dimen>
 
     <!-- Text sizes -->
     <dimen name="default_text_size">16sp</dimen>


### PR DESCRIPTION
This is a quick PR to add a little polish to the sample app UI:

### Fragment transitions

Originally there were no Fragment transitions. Now we use `.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)`

#### Before / After
<img src="https://user-images.githubusercontent.com/4624669/68895585-37b85880-06ef-11ea-9348-2e14410ca1f4.gif" width="300" /><img src="https://user-images.githubusercontent.com/4624669/68895595-3d15a300-06ef-11ea-8836-f4b3f381f16d.gif" width="300" />

### Toolbar

Originally there was no shadow and how this is a (subtle) one.

#### Before / After
<img src="https://user-images.githubusercontent.com/4624669/68895648-57e81780-06ef-11ea-9cb4-66a99528c2f6.png" width="300" /><img src="https://user-images.githubusercontent.com/4624669/68895651-5ae30800-06ef-11ea-9cf8-3ae5f5182b53.png" width="300" />
