### PR TITLE
Minor deep link changes

### DIFF
--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -158,7 +158,8 @@ class BridgeDelegate {
         if (savedInstanceState != null) {
             return false;
         }
-        ActivityManager activityManager = (ActivityManager) activity.getSystemService(Context.ACTIVITY_SERVICE);
+        ActivityManager activityManager =
+                (ActivityManager) activity.getSystemService(Context.ACTIVITY_SERVICE);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             List<ActivityManager.AppTask> appTasks = activityManager.getAppTasks();
             return appTasks.size() == 1 && appTasks.get(0).getTaskInfo().numActivities == 1;

--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -149,7 +149,8 @@ class BridgeDelegate {
     /**
      * If it's a fresh start, we can safely clear cache
      */
-    private boolean isFreshStart(@NonNull Activity activity, @NonNull Bundle savedInstanceState) {
+    private boolean isFreshStart(@NonNull Activity activity,
+                                 @Nullable Bundle savedInstanceState) {
         if (!mIsFirstCreateCall) {
             return false;
         }

--- a/bridgesample/src/main/AndroidManifest.xml
+++ b/bridgesample/src/main/AndroidManifest.xml
@@ -39,7 +39,7 @@
 
                 <data
                     android:host="large-data-activity"
-                    android:scheme="http" />
+                    android:scheme="bridgesample" />
             </intent-filter>
         </activity>
 
@@ -53,7 +53,7 @@
 
                 <data
                     android:host="success-activity"
-                    android:scheme="http" />
+                    android:scheme="bridgesample" />
             </intent-filter>
         </activity>
 
@@ -67,7 +67,7 @@
 
                 <data
                     android:host="deeplink-activity"
-                    android:scheme="http" />
+                    android:scheme="bridgesample" />
             </intent-filter>
         </activity>
 


### PR DESCRIPTION
This PR fixes a few very minor issues resulting from https://github.com/livefront/bridge/pull/50
 
- `@NonNull` is used in one place where `@Nullable` should be used.
- One new line in `BridgeDelegate` is too long.
- The deep links use dthe `http` scheme. A custom `bridgesample` scheme is used now instead.