### PR TITLE
Prepare for v1.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+Version 1.2.1 *(2019-11-14)*
+----------------------------
+
+ * Fixed bug preventing data from being properly cleared internally during configuration changes.
+ * Fixed bug resulting in non-launcher intents (such as deep links) sometimes unnecessarily clearing saved data.
+
 Version 1.2.0 *(2019-05-30)*
 ----------------------------
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.livefront:bridge:v1.2.0'
+    implementation 'com.github.livefront:bridge:v1.2.1'
 }
 ```
 


### PR DESCRIPTION
This PR updates the `REAMDE` and  `CHANGELOG` files in preparation of the `v1.2.1` release.