### PR TITLE
Use custom file storage solution to avoid Base64 encoding

### DIFF
--- a/bridge/src/androidTest/java/com/livefront/bridge/BridgeTest.java
+++ b/bridge/src/androidTest/java/com/livefront/bridge/BridgeTest.java
@@ -65,6 +65,13 @@ public class BridgeTest {
         assertEquals(data, finalTarget.getData());
         assertEquals(initialTarget, finalTarget);
 
+        // Wait for any clearing to happen on a background thread.
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            // no-op
+        }
+
         // Attempting to restore one more time will result in a failure to update the object, as
         // the stored data is deleted after the first call.
         SampleTarget additionalTarget = new SampleTarget(null);

--- a/bridge/src/androidTest/java/com/livefront/bridge/disk/FileDiskHandlerTest.java
+++ b/bridge/src/androidTest/java/com/livefront/bridge/disk/FileDiskHandlerTest.java
@@ -1,0 +1,161 @@
+package com.livefront.bridge.disk;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNull;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class FileDiskHandlerTest {
+    private final Context mContext = InstrumentationRegistry.getInstrumentation().getContext();
+    private final ExecutorService mExecutorService = Executors.newSingleThreadExecutor();
+
+    private FileDiskHandler mFileDiskHandler;
+
+    @Before
+    public void setUp() {
+        // Start each test with a fresh set of files
+        deleteAllFiles(mContext);
+
+        mFileDiskHandler = new FileDiskHandler(mContext, mExecutorService);
+    }
+
+    @Test
+    public void clear_nonMatchingKey() {
+        // Should not clear data that does not match the key
+
+        // Confirm data exists before clear
+        String key = "test";
+        byte[] bytes = new byte[]{1, 2, 3};
+        mFileDiskHandler.putBytes(key, bytes);
+
+        assertArrayEquals(bytes, mFileDiskHandler.getBytes(key));
+
+        mFileDiskHandler.clear("other-key");
+
+        assertArrayEquals(bytes, mFileDiskHandler.getBytes(key));
+    }
+
+    @Test
+    public void clear_matchingKey() {
+        // Should clear data previously stored for the given key
+
+        // Confirm data exists before clear
+        String key = "test";
+        byte[] bytes = new byte[]{1, 2, 3};
+        mFileDiskHandler.putBytes(key, bytes);
+
+        assertArrayEquals(bytes, mFileDiskHandler.getBytes(key));
+
+        mFileDiskHandler.clear(key);
+
+        assertNull(mFileDiskHandler.getBytes(key));
+    }
+
+    @Test
+    public void clearAll() {
+        // Should clear all previously saved data
+
+        // Confirm data exists before clear
+        String key = "test";
+        byte[] bytes = new byte[]{1, 2, 3};
+        mFileDiskHandler.putBytes(key, bytes);
+
+        assertArrayEquals(bytes, mFileDiskHandler.getBytes(key));
+
+        mFileDiskHandler.clearAll();
+
+        assertNull(mFileDiskHandler.getBytes(key));
+    }
+
+    @Test
+    public void constructor() {
+        // Should load existing files into memory on a background thread for quick access later
+
+        // Store some original data
+        String key = "test";
+        byte[] bytes = new byte[]{1, 2, 3};
+        mFileDiskHandler.putBytes(key, bytes);
+
+        // Create new handler to show that the data supplied to a previous handler is typically
+        // available here.
+        FileDiskHandler fileDiskHandler1 = new FileDiskHandler(mContext, mExecutorService);
+        assertArrayEquals(bytes, fileDiskHandler1.getBytes(key));
+
+        // Create new handler to show that data is loaded into memory on startup
+        FileDiskHandler fileDiskHandler2 = new FileDiskHandler(mContext, mExecutorService);
+
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            // no-op
+        }
+
+        // Clear all files manually to prove data exists in memory due to startup load
+        deleteAllFiles(mContext);
+
+        // Check the data is still stored in memory
+        assertArrayEquals(bytes, fileDiskHandler2.getBytes(key));
+
+        // Create new handler to confirm the data has been deleted from disk
+        FileDiskHandler fileDiskHandler3 = new FileDiskHandler(mContext, mExecutorService);
+
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            // no-op
+        }
+
+        assertNull(fileDiskHandler3.getBytes(key));
+    }
+
+    @Test
+    public void getBytes_dataPresent() {
+        // Should return the previously stored data
+        String key = "test";
+        byte[] bytes = new byte[]{1, 2, 3};
+        mFileDiskHandler.putBytes(key, bytes);
+
+        assertArrayEquals(bytes, mFileDiskHandler.getBytes(key));
+    }
+
+    @Test
+    public void getBytes_dataNotPresent() {
+        // Should return null
+        String key = "test";
+        assertNull(mFileDiskHandler.getBytes(key));
+    }
+
+    @Test
+    public void putBytes() {
+        // Should write over any existing data
+        String key = "test";
+        byte[] oldBytes = new byte[]{1, 2, 3};
+        mFileDiskHandler.putBytes(key, oldBytes);
+
+        byte[] newBytes = new byte[]{4, 5, 6};
+        mFileDiskHandler.putBytes(key, newBytes);
+
+        assertArrayEquals(newBytes, mFileDiskHandler.getBytes(key));
+    }
+
+    private void deleteAllFiles(@NonNull Context context) {
+        File data = context.getDir("com.livefront.bridge", Context.MODE_PRIVATE);
+        File[] files = data.listFiles();
+        if (files != null) {
+            for (File file : files) {
+                //noinspection ResultOfMethodCallIgnored
+                file.delete();
+            }
+        }
+    }
+}

--- a/bridge/src/main/java/com/livefront/bridge/disk/DiskHandler.java
+++ b/bridge/src/main/java/com/livefront/bridge/disk/DiskHandler.java
@@ -1,0 +1,41 @@
+package com.livefront.bridge.disk;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+/**
+ * A simple interface for managing the storage and retrieval of data to and from disk. All calls
+ * should be assumed to be blocking.
+ */
+public interface DiskHandler {
+    /**
+     * Clears any saved data associated with the given {@code key}.
+     *
+     * @param key The key for the save data to clear.
+     */
+    void clear(@NonNull String key);
+
+    /**
+     * Clears all saved data currently stored by the handler.
+     */
+    void clearAll();
+
+    /**
+     * Retrieves the saved data associated with the given {@code key} as a byte array (or
+     * {@code null} if there is no data available).
+     *
+     * @param key The key associated with the saved data to be retrieved.
+     * @return The saved data as a byte array (or {@code null} if there is no data available).
+     */
+    @Nullable
+    byte[] getBytes(@NonNull String key);
+
+    /**
+     * Stores the given {@code bytes} to disk and associates them with the given {@code key} for
+     * retrieval later.
+     *
+     * @param key   The key to associate with the saved data.
+     * @param bytes The data to be saved.
+     */
+    void putBytes(@NonNull String key, @NonNull byte[] bytes);
+}

--- a/bridge/src/main/java/com/livefront/bridge/disk/FileDiskHandler.java
+++ b/bridge/src/main/java/com/livefront/bridge/disk/FileDiskHandler.java
@@ -1,0 +1,237 @@
+package com.livefront.bridge.disk;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * A simple implementation of {@link DiskHandler} that saves the requested data to individual files.
+ * Similar to {@link android.content.SharedPreferences}, this implementation will begin loading the
+ * saved data into memory as soon as it is constructed and block on the first call until all data
+ * is loaded (or some cutoff is reached).
+ */
+public class FileDiskHandler implements DiskHandler {
+
+    private static final String DIRECTORY_NAME = "com.livefront.bridge";
+
+    /**
+     * Time to wait (in milliseconds) while loading the initial data in the background. After this
+     * timeout data will continue to load in the background but some calls to
+     * {@link FileDiskHandler#getBytes(String)} may then block on-demand.
+     */
+    private static final long BACKGROUND_WAIT_TIMEOUT_MS = 1000;
+
+    private final File mDirectory;
+    private final Future<?> mPendingLoadFuture;
+    private final Map<String, byte[]> mKeyByteMap = new ConcurrentHashMap<>();
+
+    /**
+     * Determines whether the {@link #waitForFilesToLoad()} call has completed in some way.
+     */
+    private volatile boolean mIsLoadedOrTimedOut = false;
+
+    /**
+     * Creates the handler and begins loading its data into memory on a background thread.
+     *
+     * @param context         The {@link Context} used to derive the file-storage location.
+     * @param executorService An {@link ExecutorService} that can be used to place the initial data
+     *                        loading on a background thread.
+     */
+    public FileDiskHandler(@NonNull Context context,
+                           @NonNull ExecutorService executorService) {
+        mDirectory = context.getDir(DIRECTORY_NAME, Context.MODE_PRIVATE);
+
+        // Load all the files into memory in the background.
+        mPendingLoadFuture = executorService.submit(new Runnable() {
+            @Override
+            public void run() {
+                loadAllFiles();
+            }
+        });
+    }
+
+    @Override
+    public void clearAll() {
+        cancelFileLoading();
+        mKeyByteMap.clear();
+        deleteFilesByKey(null);
+    }
+
+    @Override
+    public void clear(@NonNull String key) {
+        cancelFileLoading();
+        mKeyByteMap.remove(key);
+        deleteFilesByKey(key);
+    }
+
+    @Nullable
+    @Override
+    public byte[] getBytes(@NonNull String key) {
+        waitForFilesToLoad();
+        return getBytesInternal(key);
+    }
+
+    @Override
+    public void putBytes(@NonNull final String key, @NonNull final byte[] bytes) {
+        // Place the data in memory first
+        mKeyByteMap.put(key, bytes);
+
+        // Write the data to disk
+        File file = new File(mDirectory, key);
+        FileOutputStream outStream;
+        try {
+            outStream = new FileOutputStream(file);
+        } catch (FileNotFoundException e) {
+            // If there is a problem with the file we'll simply abort.
+            return;
+        }
+        try {
+            outStream.write(bytes);
+        } catch (IOException e) {
+            // Ignore
+        } finally {
+            try {
+                outStream.close();
+            } catch (IOException e) {
+                // Ignore
+            }
+        }
+    }
+
+    /**
+     * Cancels any pending file loading that happens at startup.
+     */
+    private void cancelFileLoading() {
+        mPendingLoadFuture.cancel(true);
+    }
+
+    /**
+     * Deletes all files associated with the given {@code key}. If the key is {@code null}, then
+     * all stored files will be deleted.
+     *
+     * @param key The key associated with the data to delete (or {@code null} if all data should be
+     *            deleted).
+     */
+    private void deleteFilesByKey(@Nullable String key) {
+        File[] files = mDirectory.listFiles();
+        if (files == null) {
+            return;
+        }
+        for (File file : files) {
+            if (key == null || getFileNameForKey(key).equals(file.getName())) {
+                //noinspection ResultOfMethodCallIgnored
+                file.delete();
+            }
+        }
+    }
+
+    @Nullable
+    private byte[] getBytesFromDisk(@NonNull String key) {
+        File file = getFileByKey(key);
+        if (file == null) {
+            return null;
+        }
+
+        FileInputStream inputStream;
+        try {
+            inputStream = new FileInputStream(file);
+        } catch (FileNotFoundException e) {
+            return null;
+        }
+
+        byte[] bytes = new byte[(int) file.length()];
+        try {
+            //noinspection ResultOfMethodCallIgnored
+            inputStream.read(bytes);
+        } catch (IOException e) {
+            return null;
+        } finally {
+            try {
+                inputStream.close();
+            } catch (IOException e) {
+                // Ignore
+            }
+        }
+        return bytes;
+    }
+
+    @Nullable
+    private byte[] getBytesInternal(@NonNull String key) {
+        // Check for data loaded into memory from the initial load
+        byte[] cachedBytes = mKeyByteMap.get(key);
+        if (cachedBytes != null) {
+            return cachedBytes;
+        }
+
+        // Get bytes from disk and place into memory if necessary
+        byte[] bytes = getBytesFromDisk(key);
+        if (bytes != null) {
+            mKeyByteMap.put(key, bytes);
+        }
+
+        return bytes;
+    }
+
+    private String getFileNameForKey(@NonNull String key) {
+        // For now the key and filename are equivalent
+        return key;
+    }
+
+    @Nullable
+    private File getFileByKey(@NonNull String key) {
+        File[] files = mDirectory.listFiles();
+        if (files == null) {
+            return null;
+        }
+        for (File file : files) {
+            if (getFileNameForKey(key).equals(file.getName())) {
+                return file;
+            }
+        }
+        return null;
+    }
+
+    private String getKeyForFileName(@NonNull String fileName) {
+        // For now the key and filename are equivalent
+        return fileName;
+    }
+
+    private void loadAllFiles() {
+        File[] files = mDirectory.listFiles();
+        if (files == null) {
+            return;
+        }
+        for (File file : files) {
+            // Populate the cached map
+            String key = getKeyForFileName(file.getName());
+            getBytesInternal(key);
+        }
+    }
+
+    private void waitForFilesToLoad() {
+        if (mIsLoadedOrTimedOut) {
+            // No need to wait.
+            return;
+        }
+        try {
+            mPendingLoadFuture.get(BACKGROUND_WAIT_TIMEOUT_MS, TimeUnit.SECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            // We've made a best effort to load the data in the background. We can simply proceed
+            // here.
+        }
+        mIsLoadedOrTimedOut = true;
+    }
+}


### PR DESCRIPTION
This PR replaces the usage of `SharedPreferences` with a custom file solution in order to avoid the need to Base64 encode the data before persisting it. This is to address OOM issues that can arise when calling `Base64.encodeToString` (https://github.com/livefront/bridge/issues/48).

The original need for Base64 encoding was to get around the limitation that `SharedPreferences` could not be used to store a raw `byte[]`, so the closest thing we could get was to encode the data and store it as a `String`. With a custom file solution we can simply write the bytes directly and avoid the extra, memory-intensive encoding step. While I tried to keep my implementation (`FileDiskHandler`) as simple as possible, I did add a small feature that matches some of the behavior of `SharedPreferences`: on startup, all of the file data will be read into memory on a background thread and the first call to retrieve data will block (up until a cutoff) until data has been read. This just helps ensure that all disk handling is front-loaded so that we don't block the main thread when navigating around and restoring data.