### PR TITLE
Wait for saved Bitmap to make tests more robust

### DIFF
--- a/bridgesample/src/androidTest/java/com/livefront/bridgesample/scenario/activity/LargeDataActivityTest.kt
+++ b/bridgesample/src/androidTest/java/com/livefront/bridgesample/scenario/activity/LargeDataActivityTest.kt
@@ -30,6 +30,7 @@ class LargeDataActivityTest {
     @Test
     fun generateDataAndNavigateNoCrash() {
         onView(withId(R.id.generateDataButton)).perform(click())
+        waitForBitmap()
         onView(withId(R.id.navigateButton)).perform(click())
 
         // Wait 1 second to allow a crash to occur
@@ -40,20 +41,26 @@ class LargeDataActivityTest {
     fun generateDataAndNavigateCheckData() {
         onView(withId(R.id.generateDataButton)).perform(click())
 
-        var originalBitmap: Bitmap?
-        (getCurrentActivity() as LargeDataActivity).apply {
-            originalBitmap = this.savedBitmap
-        }
+        val originalBitmap: Bitmap = waitForBitmap()
 
         onView(withId(R.id.navigateButton)).perform(click())
 
         pressBack()
 
         (getCurrentActivity() as LargeDataActivity).apply {
-            assertTrue(originalBitmap!!.sameAs(this.savedBitmap))
+            assertTrue(originalBitmap.sameAs(this.savedBitmap))
         }
 
         // Wait 1 second to allow a crash to occur
         Thread.sleep(1000)
     }
+}
+
+private fun getSavedBitmap(): Bitmap? = (getCurrentActivity() as LargeDataActivity).savedBitmap
+
+private fun waitForBitmap(): Bitmap {
+    while (getSavedBitmap() == null) {
+        Thread.sleep(100)
+    }
+    return getSavedBitmap()!!
 }

--- a/bridgesample/src/androidTest/java/com/livefront/bridgesample/scenario/activity/LargeDataBackstackActivityTest.kt
+++ b/bridgesample/src/androidTest/java/com/livefront/bridgesample/scenario/activity/LargeDataBackstackActivityTest.kt
@@ -2,18 +2,17 @@ package com.livefront.bridgesample.scenario.activity
 
 import android.graphics.Bitmap
 import android.support.test.uiautomator.UiDevice
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.util.getCurrentActivity
 import org.junit.Assert.assertTrue
 import org.junit.Rule
-
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -32,6 +31,7 @@ class LargeDataBackstackActivityTest {
     fun generateDataAndNavigateForward() {
         for (i in 1..5) {
             onView(withId(R.id.generateDataButton)).perform(click())
+            waitForBitmap()
             onView(withId(R.id.navigateButton)).perform(click())
         }
 
@@ -42,14 +42,13 @@ class LargeDataBackstackActivityTest {
     @Test
     fun generateDataAndNavigateForwardAndBackward() {
         onView(withId(R.id.generateDataButton)).perform(click())
-        var originalBitmap: Bitmap?
-        (getCurrentActivity() as LargeDataActivity).apply {
-            originalBitmap = this.savedBitmap
-        }
+
+        val originalBitmap = waitForBitmap()
         onView(withId(R.id.navigateButton)).perform(click())
 
         for (i in 1 until 5) {
             onView(withId(R.id.generateDataButton)).perform(click())
+            waitForBitmap()
             onView(withId(R.id.navigateButton)).perform(click())
         }
 
@@ -58,7 +57,7 @@ class LargeDataBackstackActivityTest {
         }
 
         (getCurrentActivity() as LargeDataActivity).apply {
-            assertTrue(originalBitmap!!.sameAs(this.savedBitmap))
+            assertTrue(originalBitmap.sameAs(this.savedBitmap))
         }
 
         // Wait 1 second to allow a crash to occur
@@ -68,14 +67,13 @@ class LargeDataBackstackActivityTest {
     @Test
     fun generateDataAndNavigateForwardRotateBackward() {
         onView(withId(R.id.generateDataButton)).perform(click())
-        var originalBitmap: Bitmap? = null
-        (getCurrentActivity() as LargeDataActivity).apply {
-            originalBitmap = this.savedBitmap
-        }
+
+        val originalBitmap = waitForBitmap()
         onView(withId(R.id.navigateButton)).perform(click())
 
         for (i in 1 until 5) {
             onView(withId(R.id.generateDataButton)).perform(click())
+            waitForBitmap()
             onView(withId(R.id.navigateButton)).perform(click())
         }
 
@@ -86,10 +84,19 @@ class LargeDataBackstackActivityTest {
         }
 
         (getCurrentActivity() as LargeDataActivity).apply {
-            assertTrue(originalBitmap!!.sameAs(this.savedBitmap))
+            assertTrue(originalBitmap.sameAs(this.savedBitmap))
         }
 
         // Wait 1 second to allow a crash to occur
         Thread.sleep(1000)
     }
+}
+
+private fun getSavedBitmap(): Bitmap? = (getCurrentActivity() as LargeDataActivity).savedBitmap
+
+private fun waitForBitmap(): Bitmap {
+    while (getSavedBitmap() == null) {
+        Thread.sleep(100)
+    }
+    return getSavedBitmap()!!
 }


### PR DESCRIPTION
I noticed that the tests can be a bit flaky because the `Bitmap` is generated in the background and sometimes we start navigating before it is done. I've added some `waitForBitmap` calls to make these tests more robust.