### PR TITLE
Catch CancellationException that may result from cancelling the Future in clear / clearAll

### DIFF
--- a/bridge/src/androidTest/java/com/livefront/bridge/disk/FileDiskHandlerTest.java
+++ b/bridge/src/androidTest/java/com/livefront/bridge/disk/FileDiskHandlerTest.java
@@ -119,6 +119,13 @@ public class FileDiskHandlerTest {
     }
 
     @Test
+    public void getBytes_afterCancelling() {
+        // Should not trigger a CancellationException
+        mFileDiskHandler.clearAll();
+        mFileDiskHandler.getBytes("test");
+    }
+
+    @Test
     public void getBytes_dataPresent() {
         // Should return the previously stored data
         String key = "test";

--- a/bridge/src/main/java/com/livefront/bridge/disk/FileDiskHandler.java
+++ b/bridge/src/main/java/com/livefront/bridge/disk/FileDiskHandler.java
@@ -10,6 +10,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -228,7 +229,10 @@ public class FileDiskHandler implements DiskHandler {
         }
         try {
             mPendingLoadFuture.get(BACKGROUND_WAIT_TIMEOUT_MS, TimeUnit.SECONDS);
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+        } catch (CancellationException |
+                InterruptedException |
+                ExecutionException |
+                TimeoutException e) {
             // We've made a best effort to load the data in the background. We can simply proceed
             // here.
         }


### PR DESCRIPTION
This PR fixes a rare but possible issue in which a `CancellationException` is thrown in `FileDiskHandler` when calling `waitForFilesToLoad`. In order for this to happen the `mPendingLoadFuture` must be ongoing while `clear(...)` or `clearAll()` is called (which results in a call to `mPendingLoadFuture.cancel(true)`). The next call to `FileDiskHandler.getBytes(...)` would then throw the exception. I've never actually seen this happen and can't manually reproduce it in the sample app but I've written a test that fails without this fix and it is possible in theory as the result of a race condition. The solution is simply to ensure that we also catch the `CancellationException` in `waitForFilesToLoad`.