### PR TITLE
Prepare for v1.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+Version 1.3.1 *(2021-03-02)*
+----------------------------
+
+ * Prevented `CancellationException` that might result due to a rare race condition on startup.
+
 Version 1.3.0 *(2020-12-07)*
 ----------------------------
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.livefront:bridge:v1.3.0'
+    implementation 'com.github.livefront:bridge:v1.3.1'
 }
 ```
 


### PR DESCRIPTION
This PR updates the REAMDE and CHANGELOG files in preparation of the v1.3.1 release. This is just a quick bug fix release.