### PR TITLE
Update to AndroidX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,15 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-28.0.3
-    - android-28
+    - build-tools-30.0.3
+    - android-30
     - android-22
     - sys-img-armeabi-v7a-android-22
+  licenses:
+    - 'android-sdk-license-.+'
+
+before_install:
+  - yes | sdkmanager "platforms;android-30"
 
 # Emulator Management: Create, Start and Wait
 before_script:

--- a/bridge/build.gradle
+++ b/bridge/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.annotation:annotation:1.1.0'
 
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
 }
 
 // build a jar with source files

--- a/bridge/build.gradle
+++ b/bridge/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion 30
+    buildToolsVersion "30.0.3"
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 30
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/bridge/build.gradle
+++ b/bridge/build.gradle
@@ -18,7 +18,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'androidx.annotation:annotation:1.1.0'
 
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/bridge/src/androidTest/java/com/livefront/bridge/BridgeTest.java
+++ b/bridge/src/androidTest/java/com/livefront/bridge/BridgeTest.java
@@ -5,9 +5,9 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.livefront.bridge.helper.Data;

--- a/bridge/src/androidTest/java/com/livefront/bridge/helper/Data.java
+++ b/bridge/src/androidTest/java/com/livefront/bridge/helper/Data.java
@@ -2,7 +2,8 @@ package com.livefront.bridge.helper;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+
+import androidx.annotation.NonNull;
 
 import java.util.Objects;
 

--- a/bridge/src/androidTest/java/com/livefront/bridge/helper/SampleTarget.java
+++ b/bridge/src/androidTest/java/com/livefront/bridge/helper/SampleTarget.java
@@ -1,8 +1,9 @@
 package com.livefront.bridge.helper;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.Objects;
 

--- a/bridge/src/androidTest/java/com/livefront/bridge/helper/Saveable.java
+++ b/bridge/src/androidTest/java/com/livefront/bridge/helper/Saveable.java
@@ -1,8 +1,9 @@
 package com.livefront.bridge.helper;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Simple interface that can be implemented by test classes and checked inside a

--- a/bridge/src/main/java/com/livefront/bridge/ActivityLifecycleCallbacksAdapter.java
+++ b/bridge/src/main/java/com/livefront/bridge/ActivityLifecycleCallbacksAdapter.java
@@ -2,9 +2,7 @@ package com.livefront.bridge;
 
 import android.app.Activity;
 import android.app.Application.ActivityLifecycleCallbacks;
-import android.os.Build;
 import android.os.Bundle;
-import android.support.annotation.RequiresApi;
 
 abstract class ActivityLifecycleCallbacksAdapter implements ActivityLifecycleCallbacks {
 

--- a/bridge/src/main/java/com/livefront/bridge/Bridge.java
+++ b/bridge/src/main/java/com/livefront/bridge/Bridge.java
@@ -4,9 +4,10 @@ import android.content.Context;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public class Bridge {
 

--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -9,9 +9,10 @@ import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.livefront.bridge.disk.DiskHandler;
 import com.livefront.bridge.disk.FileDiskHandler;

--- a/bridge/src/main/java/com/livefront/bridge/NoOpSavedStateHandler.java
+++ b/bridge/src/main/java/com/livefront/bridge/NoOpSavedStateHandler.java
@@ -1,8 +1,9 @@
 package com.livefront.bridge;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 class NoOpSavedStateHandler implements SavedStateHandler {
 

--- a/bridge/src/main/java/com/livefront/bridge/SavedStateHandler.java
+++ b/bridge/src/main/java/com/livefront/bridge/SavedStateHandler.java
@@ -1,8 +1,9 @@
 package com.livefront.bridge;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * A handler for generic, non-{@link android.view.View} objects. To save the state of Views, see

--- a/bridge/src/main/java/com/livefront/bridge/ViewSavedStateHandler.java
+++ b/bridge/src/main/java/com/livefront/bridge/ViewSavedStateHandler.java
@@ -1,9 +1,10 @@
 package com.livefront.bridge;
 
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * A handler specifically for saving and restoring the state of {@link android.view.View} objects.

--- a/bridge/src/main/java/com/livefront/bridge/disk/DiskHandler.java
+++ b/bridge/src/main/java/com/livefront/bridge/disk/DiskHandler.java
@@ -1,7 +1,7 @@
 package com.livefront.bridge.disk;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * A simple interface for managing the storage and retrieval of data to and from disk. All calls

--- a/bridge/src/main/java/com/livefront/bridge/disk/FileDiskHandler.java
+++ b/bridge/src/main/java/com/livefront/bridge/disk/FileDiskHandler.java
@@ -1,8 +1,9 @@
 package com.livefront.bridge.disk;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/bridge/src/main/java/com/livefront/bridge/util/BundleUtil.java
+++ b/bridge/src/main/java/com/livefront/bridge/util/BundleUtil.java
@@ -2,8 +2,9 @@ package com.livefront.bridge.util;
 
 import android.os.Bundle;
 import android.os.Parcel;
-import android.support.annotation.NonNull;
 import android.util.Base64;
+
+import androidx.annotation.NonNull;
 
 /**
  * Helper class for converting {@link Bundle} instances to and from bytes and encoded Strings.

--- a/bridge/src/main/java/com/livefront/bridge/wrapper/BitmapWrapper.java
+++ b/bridge/src/main/java/com/livefront/bridge/wrapper/BitmapWrapper.java
@@ -3,7 +3,8 @@ package com.livefront.bridge.wrapper;
 import android.graphics.Bitmap;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+
+import androidx.annotation.NonNull;
 
 import java.nio.ByteBuffer;
 

--- a/bridge/src/main/java/com/livefront/bridge/wrapper/WrapperUtils.java
+++ b/bridge/src/main/java/com/livefront/bridge/wrapper/WrapperUtils.java
@@ -3,7 +3,8 @@ package com.livefront.bridge.wrapper;
 import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.os.Parcel;
-import android.support.annotation.NonNull;
+
+import androidx.annotation.NonNull;
 
 import java.util.Set;
 

--- a/bridgesample/build.gradle
+++ b/bridgesample/build.gradle
@@ -26,7 +26,7 @@ androidExtensions {
     experimental = true
 }
 
-def stateSaverVersion = "1.3.1"
+def stateSaverVersion = "1.4.1"
 
 dependencies {
     // Kotlin

--- a/bridgesample/build.gradle
+++ b/bridgesample/build.gradle
@@ -27,7 +27,6 @@ androidExtensions {
 }
 
 def stateSaverVersion = "1.3.1"
-def supportLibraryVersion = '28.0.0'
 
 dependencies {
     // Kotlin
@@ -40,14 +39,17 @@ dependencies {
     implementation "com.evernote:android-state:$stateSaverVersion"
     kapt "com.evernote:android-state-processor:$stateSaverVersion"
 
-    // Support Library
-    implementation "com.android.support:appcompat-v7:$supportLibraryVersion"
-    implementation "com.android.support:design:$supportLibraryVersion"
-    implementation "com.android.support:recyclerview-v7:$supportLibraryVersion"
+    // AndroidX
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.fragment:fragment:1.3.1'
+    implementation 'androidx.recyclerview:recyclerview:1.1.0'
 
-    androidTestImplementation 'com.android.support.test.uiautomator:uiautomator-v18:2.1.3'
+    // Material
+    implementation 'com.google.android.material:material:1.3.0'
+
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.ext:junit-ktx:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
 }

--- a/bridgesample/build.gradle
+++ b/bridgesample/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     defaultConfig {
         applicationId "com.livefront.bridgesample"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/bridgesample/build.gradle
+++ b/bridgesample/build.gradle
@@ -47,9 +47,9 @@ dependencies {
     // Material
     implementation 'com.google.android.material:material:1.3.0'
 
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.ext:junit-ktx:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.ext:junit-ktx:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
 }

--- a/bridgesample/src/androidTest/java/com/livefront/bridgesample/scenario/activity/LargeDataActivityTest.kt
+++ b/bridgesample/src/androidTest/java/com/livefront/bridgesample/scenario/activity/LargeDataActivityTest.kt
@@ -1,18 +1,17 @@
 package com.livefront.bridgesample.scenario.activity
 
 import android.graphics.Bitmap
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.util.getCurrentActivity
 import org.junit.Assert.assertTrue
 import org.junit.Rule
-
 import org.junit.Test
 import org.junit.runner.RunWith
 

--- a/bridgesample/src/androidTest/java/com/livefront/bridgesample/scenario/activity/LargeDataBackstackActivityTest.kt
+++ b/bridgesample/src/androidTest/java/com/livefront/bridgesample/scenario/activity/LargeDataBackstackActivityTest.kt
@@ -1,7 +1,6 @@
 package com.livefront.bridgesample.scenario.activity
 
 import android.graphics.Bitmap
-import android.support.test.uiautomator.UiDevice
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.action.ViewActions.click
@@ -9,6 +8,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.util.getCurrentActivity
 import org.junit.Assert.assertTrue

--- a/bridgesample/src/main/java/com/livefront/bridgesample/base/BridgeBaseActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/base/BridgeBaseActivity.kt
@@ -1,7 +1,7 @@
 package com.livefront.bridgesample.base
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import com.livefront.bridge.Bridge
 
 abstract class BridgeBaseActivity : AppCompatActivity() {

--- a/bridgesample/src/main/java/com/livefront/bridgesample/base/BridgeBaseFragment.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/base/BridgeBaseFragment.kt
@@ -1,8 +1,8 @@
 package com.livefront.bridgesample.base
 
 import android.os.Bundle
-import android.support.v4.app.Fragment
-import android.support.v4.app.FragmentStatePagerAdapter
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentStatePagerAdapter
 import com.livefront.bridge.Bridge
 
 abstract class BridgeBaseFragment : Fragment() {

--- a/bridgesample/src/main/java/com/livefront/bridgesample/base/NonBridgeBaseActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/base/NonBridgeBaseActivity.kt
@@ -1,7 +1,7 @@
 package com.livefront.bridgesample.base
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import com.evernote.android.state.StateSaver
 
 abstract class NonBridgeBaseActivity : AppCompatActivity() {

--- a/bridgesample/src/main/java/com/livefront/bridgesample/base/NonBridgeBaseFragment.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/base/NonBridgeBaseFragment.kt
@@ -1,7 +1,7 @@
 package com.livefront.bridgesample.base
 
 import android.os.Bundle
-import android.support.v4.app.Fragment
+import androidx.fragment.app.Fragment
 import com.evernote.android.state.StateSaver
 
 open class NonBridgeBaseFragment : Fragment() {

--- a/bridgesample/src/main/java/com/livefront/bridgesample/common/view/BitmapGeneratorView.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/common/view/BitmapGeneratorView.kt
@@ -4,9 +4,9 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
-import android.support.annotation.StringRes
 import android.util.AttributeSet
 import android.widget.RelativeLayout
+import androidx.annotation.StringRes
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.scenario.activity.SuccessActivity
 import com.livefront.bridgesample.util.generateNoisyStripedBitmap

--- a/bridgesample/src/main/java/com/livefront/bridgesample/main/adapter/MainAdapter.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/main/adapter/MainAdapter.kt
@@ -1,7 +1,7 @@
 package com.livefront.bridgesample.main.adapter
 
-import android.support.v7.widget.RecyclerView
 import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.main.adapter.MainAdapter.MainViewHolder
 import com.livefront.bridgesample.main.model.MainItem

--- a/bridgesample/src/main/java/com/livefront/bridgesample/main/model/MainItem.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/main/model/MainItem.kt
@@ -2,7 +2,7 @@ package com.livefront.bridgesample.main.model
 
 import android.content.Intent
 import android.os.Parcelable
-import android.support.annotation.StringRes
+import androidx.annotation.StringRes
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize

--- a/bridgesample/src/main/java/com/livefront/bridgesample/main/view/MainItemView.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/main/view/MainItemView.kt
@@ -1,9 +1,9 @@
 package com.livefront.bridgesample.main.view
 
 import android.content.Context
-import android.support.annotation.DrawableRes
 import android.util.AttributeSet
 import android.widget.RelativeLayout
+import androidx.annotation.DrawableRes
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.util.layoutInflater
 import kotlinx.android.synthetic.main.view_main_item_content.view.descriptionView

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/DeeplinkActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/DeeplinkActivity.kt
@@ -2,7 +2,7 @@ package com.livefront.bridgesample.scenario.activity
 
 import android.content.Intent
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 
 class DeeplinkActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/FragmentContainerActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/FragmentContainerActivity.kt
@@ -5,10 +5,10 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
-import android.support.annotation.StringRes
-import android.support.v4.app.Fragment
-import android.support.v4.app.FragmentTransaction
 import android.view.MenuItem
+import androidx.annotation.StringRes
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentTransaction
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.base.BridgeBaseActivity
 import com.livefront.bridgesample.scenario.activity.FragmentContainerActivity.Companion.getNavigationIntent

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/FragmentContainerActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/FragmentContainerActivity.kt
@@ -62,7 +62,7 @@ class FragmentContainerActivity : BridgeBaseActivity(), FragmentNavigationManage
             activity: FragmentContainerActivity
         ): FragmentData = activity
                 .intent
-                .getParcelableExtra(FRAGMENT_DATA_KEY)
+                .getParcelableExtra(FRAGMENT_DATA_KEY)!!
 
         fun getNavigationIntent(
             context: Context,

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/LargeDataActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/LargeDataActivity.kt
@@ -52,7 +52,7 @@ class LargeDataActivity : BridgeBaseActivity() {
             activity: LargeDataActivity
         ): LargeDataActivityArguments = activity
                 .intent
-                .getParcelableExtra(ARGUMENTS_KEY)
+                .getParcelableExtra(ARGUMENTS_KEY)!!
 
         fun getNavigationIntent(
             context: Context,

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/NonBridgeLargeDataActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/NonBridgeLargeDataActivity.kt
@@ -52,7 +52,7 @@ class NonBridgeLargeDataActivity : NonBridgeBaseActivity() {
             activity: NonBridgeLargeDataActivity
         ): NonBridgeLargeDataActivityArguments = activity
                 .intent
-                .getParcelableExtra(ARGUMENTS_KEY)
+                .getParcelableExtra(ARGUMENTS_KEY)!!
 
 
         fun getNavigationIntent(

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/ViewContainerActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/ViewContainerActivity.kt
@@ -5,11 +5,11 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
-import android.support.annotation.LayoutRes
-import android.support.annotation.StringRes
-import android.support.v4.app.Fragment
 import android.view.MenuItem
 import android.view.View
+import androidx.annotation.LayoutRes
+import androidx.annotation.StringRes
+import androidx.fragment.app.Fragment
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.base.BridgeBaseActivity
 import com.livefront.bridgesample.scenario.activity.FragmentContainerActivity.Companion.getNavigationIntent

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/ViewContainerActivity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/activity/ViewContainerActivity.kt
@@ -55,7 +55,7 @@ class ViewContainerActivity : BridgeBaseActivity() {
             activity: ViewContainerActivity
         ): ViewData = activity
                 .intent
-                .getParcelableExtra(DATA_KEY)
+                .getParcelableExtra(DATA_KEY)!!
     }
 }
 

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/LargeDataFragment.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/LargeDataFragment.kt
@@ -63,7 +63,7 @@ class LargeDataFragment : BridgeBaseFragment() {
             fragment: LargeDataFragment
         ): LargeDataArguments = fragment
                 .requireArguments()
-                .getParcelable(ARGUMENTS_KEY)
+                .getParcelable(ARGUMENTS_KEY)!!
 
         fun getFragmentData(
             largeDataArguments: LargeDataArguments = LargeDataArguments()

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/LargeDataFragment.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/LargeDataFragment.kt
@@ -24,7 +24,7 @@ class LargeDataFragment : BridgeBaseFragment() {
 
     private lateinit var fragmentNavigationManager: FragmentNavigationManager
 
-    override fun onAttach(context: Context?) {
+    override fun onAttach(context: Context) {
         super.onAttach(context)
         fragmentNavigationManager = context as FragmentNavigationManager
     }
@@ -62,7 +62,7 @@ class LargeDataFragment : BridgeBaseFragment() {
         fun getArguments(
             fragment: LargeDataFragment
         ): LargeDataArguments = fragment
-                .arguments!!
+                .requireArguments()
                 .getParcelable(ARGUMENTS_KEY)
 
         fun getFragmentData(

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/NonBridgeLargeDataFragment.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/NonBridgeLargeDataFragment.kt
@@ -57,7 +57,7 @@ class NonBridgeLargeDataFragment : NonBridgeBaseFragment() {
             fragment: NonBridgeLargeDataFragment
         ): NonBridgeLargeDataArguments = fragment
                 .requireArguments()
-                .getParcelable(ARGUMENTS_KEY)
+                .getParcelable(ARGUMENTS_KEY)!!
 
         fun getFragmentData(
             nonBridgeLargeDataArguments: NonBridgeLargeDataArguments = NonBridgeLargeDataArguments()

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/NonBridgeLargeDataFragment.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/NonBridgeLargeDataFragment.kt
@@ -21,7 +21,7 @@ class NonBridgeLargeDataFragment : NonBridgeBaseFragment() {
 
     private lateinit var fragmentNavigationManager: FragmentNavigationManager
 
-    override fun onAttach(context: Context?) {
+    override fun onAttach(context: Context) {
         super.onAttach(context)
         fragmentNavigationManager = context as FragmentNavigationManager
     }
@@ -56,7 +56,7 @@ class NonBridgeLargeDataFragment : NonBridgeBaseFragment() {
         fun getArguments(
             fragment: NonBridgeLargeDataFragment
         ): NonBridgeLargeDataArguments = fragment
-                .arguments!!
+                .requireArguments()
                 .getParcelable(ARGUMENTS_KEY)
 
         fun getFragmentData(

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/StatePagerFragment.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/StatePagerFragment.kt
@@ -2,12 +2,12 @@ package com.livefront.bridgesample.scenario.fragment
 
 import android.os.Bundle
 import android.os.Parcelable
-import android.support.v4.app.Fragment
-import android.support.v4.app.FragmentStatePagerAdapter
-import android.support.v4.view.ViewPager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentStatePagerAdapter
+import androidx.viewpager.widget.ViewPager
 import com.livefront.bridge.Bridge
 import com.livefront.bridgesample.R
 import com.livefront.bridgesample.base.BridgeBaseFragment
@@ -29,7 +29,10 @@ class StatePagerFragment : BridgeBaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        viewPager.adapter = object : FragmentStatePagerAdapter(childFragmentManager) {
+        viewPager.adapter = object : FragmentStatePagerAdapter(
+                childFragmentManager,
+                BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT
+        ) {
             override fun getItem(
                 position: Int
             ): Fragment = when (getArguments(this@StatePagerFragment).mode) {
@@ -57,7 +60,7 @@ class StatePagerFragment : BridgeBaseFragment() {
         fun getArguments(
             fragment: StatePagerFragment
         ): StatePagerArguments = fragment
-                .arguments!!
+                .requireArguments()
                 .getParcelable(ARGUMENTS_KEY)
 
         fun getFragmentData(arguments: StatePagerArguments) = FragmentData(

--- a/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/StatePagerFragment.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/scenario/fragment/StatePagerFragment.kt
@@ -61,7 +61,7 @@ class StatePagerFragment : BridgeBaseFragment() {
             fragment: StatePagerFragment
         ): StatePagerArguments = fragment
                 .requireArguments()
-                .getParcelable(ARGUMENTS_KEY)
+                .getParcelable(ARGUMENTS_KEY)!!
 
         fun getFragmentData(arguments: StatePagerArguments) = FragmentData(
                 when (arguments.mode) {

--- a/bridgesample/src/main/java/com/livefront/bridgesample/util/Activity.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/util/Activity.kt
@@ -1,10 +1,10 @@
 package com.livefront.bridgesample.util
 
 import android.app.Activity
-import android.support.annotation.StringRes
-import android.support.v7.app.AppCompatActivity
-import android.support.v7.widget.Toolbar
 import android.view.MenuItem
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
 
 /**
  * Helper method for handling the standard "home as back press" behavior in

--- a/bridgesample/src/main/java/com/livefront/bridgesample/util/FragmentNavigationManager.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/util/FragmentNavigationManager.kt
@@ -1,6 +1,6 @@
 package com.livefront.bridgesample.util
 
-import android.support.v4.app.Fragment
+import androidx.fragment.app.Fragment
 
 /**
  * Helper interface to provide fragment navigation.

--- a/bridgesample/src/main/java/com/livefront/bridgesample/util/View.kt
+++ b/bridgesample/src/main/java/com/livefront/bridgesample/util/View.kt
@@ -1,8 +1,8 @@
 package com.livefront.bridgesample.util
 
-import android.support.annotation.StringRes
 import android.view.LayoutInflater
 import android.view.View
+import androidx.annotation.StringRes
 
 fun View.getString(@StringRes stringRes: Int): String = context.getString(stringRes)
 

--- a/bridgesample/src/main/res/layout/activity_main.xml
+++ b/bridgesample/src/main/res/layout/activity_main.xml
@@ -15,10 +15,10 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layoutManager="android.support.v7.widget.LinearLayoutManager" />
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
 </LinearLayout>

--- a/bridgesample/src/main/res/layout/basic_toolbar.xml
+++ b/bridgesample/src/main/res/layout/basic_toolbar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.Toolbar
+<androidx.appcompat.widget.Toolbar
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/toolbar"

--- a/bridgesample/src/main/res/layout/fragment_pager.xml
+++ b/bridgesample/src/main/res/layout/fragment_pager.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v4.view.ViewPager
+<androidx.viewpager.widget.ViewPager
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/viewPager"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.support.design.widget.TabLayout
+    <com.google.android.material.tabs.TabLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="top"
@@ -15,4 +15,4 @@
         app:tabMode="scrollable"
         app:tabTextColor="@android:color/white" />
 
-</android.support.v4.view.ViewPager>
+</androidx.viewpager.widget.ViewPager>

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:4.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.21'
+    ext.kotlin_version = '1.4.31'
 
     repositories {
         jcenter()

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@
 # For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 
-android.enableJetifier=true
+android.enableJetifier=false
 android.useAndroidX=true
 
 # Specifies the JVM arguments used for the daemon process.

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,9 @@
 # For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 
+android.enableJetifier=true
+android.useAndroidX=true
+
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed May 29 09:07:44 CDT 2019
+#Sun Mar 14 14:43:20 CDT 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip


### PR DESCRIPTION
This PR updates the project to use AndroidX so that consumers don't require Jetifier in order to use it. It's worth noting that the library's only dependency on the support library (and now AndroidX) is via the `@NonNull` / `@Nullable` annotations, so the bulk of the updates here are actually just in the sample app.

While I was making this change, I decided to quickly update all other dependencies that have been due for updates as well, including:

- Kotlin
- The gradle wrapper and Android Gradle Plugin
- All the test dependencies
- The State Saver library
- The build tools and target SDK versions

Making these changes made me realize that at some point I need to clean up the `build.gradle` files by introducing a `dependencies.gradle` file with all the version information, but I'd like to leave that to a later PR.