### PR TITLE
Prepare for v2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+Version 2.0.0 *(2021-03-16)*
+----------------------------
+
+ * `Bridge` now depends on AndroidX rather than the support libraries.
+
 Version 1.3.1 *(2021-03-02)*
 ----------------------------
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A library for avoiding TransactionTooLargeException during state saving and rest
 * [Limitations](#limitations)
 * [Testing](#testing)
 * [License](#license)
-* [Javadoc](https://jitpack.io/com/github/livefront/bridge/v1.1.1/javadoc/index.html)
+* [Javadoc](https://jitpack.io/com/github/livefront/bridge/v2.0.0/javadoc/index.html)
 
 <a name="motivation"></a>
 ## Motivation
@@ -140,7 +140,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.livefront:bridge:v1.3.1'
+    implementation 'com.github.livefront:bridge:v2.0.0'
 }
 ```
 


### PR DESCRIPTION
This PR updates the `REAMDE` and `CHANGELOG` files in preparation of the v2.0.0 release. This includes a single change to update to AndroidX.