### PR TITLE
Better thread safety

### DIFF
--- a/bridge/src/main/java/com/livefront/bridge/Bridge.java
+++ b/bridge/src/main/java/com/livefront/bridge/Bridge.java
@@ -9,7 +9,11 @@ import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 public class Bridge {
+    private static final ExecutorService sExecutorService = Executors.newCachedThreadPool();
 
     private static volatile BridgeDelegate sDelegate;
 
@@ -41,7 +45,11 @@ public class Bridge {
     public static void clearAll(@NonNull Context context) {
         BridgeDelegate delegate = sDelegate != null
                 ? sDelegate
-                : new BridgeDelegate(context, new NoOpSavedStateHandler(), null);
+                : new BridgeDelegate(
+                        context,
+                        sExecutorService,
+                        new NoOpSavedStateHandler(),
+                        null);
         delegate.clearAll();
     }
 
@@ -83,7 +91,11 @@ public class Bridge {
             @NonNull Context context,
             @NonNull SavedStateHandler savedStateHandler,
             @Nullable ViewSavedStateHandler viewSavedStateHandler) {
-        sDelegate = new BridgeDelegate(context, savedStateHandler, viewSavedStateHandler);
+        sDelegate = new BridgeDelegate(
+                context,
+                sExecutorService,
+                savedStateHandler,
+                viewSavedStateHandler);
     }
 
     /**

--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -5,7 +5,6 @@ import android.app.Activity;
 import android.app.ActivityManager;
 import android.app.Application;
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
@@ -55,20 +54,18 @@ class BridgeDelegate {
     private Map<String, Bundle> mUuidBundleMap = new ConcurrentHashMap<>();
     private Map<Object, String> mObjectUuidMap = new WeakHashMap<>();
     private SavedStateHandler mSavedStateHandler;
-    private SharedPreferences mSharedPreferences;
     private ViewSavedStateHandler mViewSavedStateHandler;
 
     BridgeDelegate(@NonNull Context context,
                    @NonNull SavedStateHandler savedStateHandler,
                    @Nullable ViewSavedStateHandler viewSavedStateHandler) {
-        mSharedPreferences = context.getSharedPreferences(TAG, Context.MODE_PRIVATE);
         mSavedStateHandler = savedStateHandler;
         mViewSavedStateHandler = viewSavedStateHandler;
         registerForLifecycleEvents(context);
         mDiskHandler = new FileDiskHandler(context, mExecutorService);
 
         // Clear out any data from old storage mechanism
-        mSharedPreferences.edit().clear().apply();
+        context.getSharedPreferences(TAG, Context.MODE_PRIVATE).edit().clear().apply();
     }
 
     private void checkForViewSavedStateHandler() {

--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -43,18 +43,19 @@ class BridgeDelegate {
     private static final String KEY_UUID = "uuid_%s";
     private static final String KEY_WRAPPED_VIEW_RESULT = "wrapped-view-result";
 
+    private final DiskHandler mDiskHandler;
+    private final ExecutorService mExecutorService = Executors.newCachedThreadPool();
+    private final List<Runnable> mPendingWriteTasks = new CopyOnWriteArrayList<>();
+    private final Map<String, Bundle> mUuidBundleMap = new ConcurrentHashMap<>();
+    private final Map<Object, String> mObjectUuidMap = new WeakHashMap<>();
+    private final SavedStateHandler mSavedStateHandler;
+    private final ViewSavedStateHandler mViewSavedStateHandler;
+
     private int mActivityCount = 0;
     private boolean mIsClearAllowed = false;
     private boolean mIsConfigChange = false;
     private boolean mIsFirstCreateCall = true;
     private volatile CountDownLatch mPendingWriteTasksLatch = null;
-    private DiskHandler mDiskHandler;
-    private ExecutorService mExecutorService = Executors.newCachedThreadPool();
-    private List<Runnable> mPendingWriteTasks = new CopyOnWriteArrayList<>();
-    private Map<String, Bundle> mUuidBundleMap = new ConcurrentHashMap<>();
-    private Map<Object, String> mObjectUuidMap = new WeakHashMap<>();
-    private SavedStateHandler mSavedStateHandler;
-    private ViewSavedStateHandler mViewSavedStateHandler;
 
     BridgeDelegate(@NonNull Context context,
                    @NonNull SavedStateHandler savedStateHandler,

--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 class BridgeDelegate {
@@ -44,7 +43,7 @@ class BridgeDelegate {
     private static final String KEY_WRAPPED_VIEW_RESULT = "wrapped-view-result";
 
     private final DiskHandler mDiskHandler;
-    private final ExecutorService mExecutorService = Executors.newCachedThreadPool();
+    private final ExecutorService mExecutorService;
     private final List<Runnable> mPendingWriteTasks = new CopyOnWriteArrayList<>();
     private final Map<String, Bundle> mUuidBundleMap = new ConcurrentHashMap<>();
     private final Map<Object, String> mObjectUuidMap = new WeakHashMap<>();
@@ -58,9 +57,11 @@ class BridgeDelegate {
     private volatile CountDownLatch mPendingWriteTasksLatch = null;
 
     BridgeDelegate(@NonNull Context context,
+                   @NonNull ExecutorService executorService,
                    @NonNull SavedStateHandler savedStateHandler,
                    @Nullable ViewSavedStateHandler viewSavedStateHandler) {
         mSavedStateHandler = savedStateHandler;
+        mExecutorService = executorService;
         mViewSavedStateHandler = viewSavedStateHandler;
         mDiskHandler = new FileDiskHandler(context, mExecutorService);
 

--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -61,8 +61,9 @@ class BridgeDelegate {
                    @Nullable ViewSavedStateHandler viewSavedStateHandler) {
         mSavedStateHandler = savedStateHandler;
         mViewSavedStateHandler = viewSavedStateHandler;
-        registerForLifecycleEvents(context);
         mDiskHandler = new FileDiskHandler(context, mExecutorService);
+
+        registerForLifecycleEvents(context);
 
         // Clear out any data from old storage mechanism
         context.getSharedPreferences(TAG, Context.MODE_PRIVATE).edit().clear().apply();


### PR DESCRIPTION
This PR attempts to make some minor thread safety improvements to try and avoid a strange NPE reported in https://github.com/livefront/bridge/issues/69 . The changes include

- Make all member variables inside `BridgeDelegate` `final` where possible. This should have already been and was definitely an oversight.
- Don't call `registerForLifecycleEvents` until after all relevant member variables are initialized. There is potentially the chance that a callback is triggered before the constructor completes and therefore accesses a null variable.
- Create an `ExecutorService` in the `Bridge` class and hold as a static variable. I don't love the introduction of another static variable but I think there is a case that having the `ExecutorService` defined inside the `BridgeDelegate` class can potentially lead to strange behavior when `Bridge.clearAll` is called before `Bridge.initialize`. Under aggressive GC conditions, after `Bridge.clearAll` returns, there are no more references to the one-off `BridgeDelegate` instance even though the internal `ExecutorService` is still processing work. Elevating the scope of the `ExecutorService` should ensure this object is kept until all work is complete.