### PR TITLE
Prepare for v2.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+Version 2.0.1 *(2021-03-31)*
+----------------------------
+
+ * Improve thread-safety to avoid rare NullPointerException.
+
 Version 2.0.0 *(2021-03-16)*
 ----------------------------
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A library for avoiding TransactionTooLargeException during state saving and rest
 * [Limitations](#limitations)
 * [Testing](#testing)
 * [License](#license)
-* [Javadoc](https://jitpack.io/com/github/livefront/bridge/v2.0.0/javadoc/index.html)
+* [Javadoc](https://jitpack.io/com/github/livefront/bridge/v2.0.1/javadoc/index.html)
 
 <a name="motivation"></a>
 ## Motivation
@@ -140,7 +140,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.livefront:bridge:v2.0.0'
+    implementation 'com.github.livefront:bridge:v2.0.1'
 }
 ```
 


### PR DESCRIPTION
This PR updates the REAMDE and CHANGELOG files in preparation of the v2.0.1 release. This includes changes from a single PR to improve thread-safety.