### PR TITLE
Safer read handling

### DIFF
--- a/bridge/src/androidTest/java/com/livefront/bridge/BridgeDelegateTest.java
+++ b/bridge/src/androidTest/java/com/livefront/bridge/BridgeDelegateTest.java
@@ -3,6 +3,7 @@ package com.livefront.bridge;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
@@ -43,7 +44,69 @@ public class BridgeDelegateTest {
     private final BridgeDelegate mDelegate = buildBridgeDelegate();
 
     @Test
-    public void restoreInstanceState_differentInstance() {
+    public void restoreInstanceState_differentInstance_malformedData() {
+        // Should not restore the data to the final target and should not throw an exception.
+        Data data = new Data("Text");
+        SampleTarget initialTarget = new SampleTarget(data);
+        Bundle initialBundle = new Bundle();
+
+        mDelegate.saveInstanceState(initialTarget, initialBundle);
+
+        // Overwrite the data with malformed data
+        String uuidKey = String.format("uuid_%s", initialTarget.getClass().getName());
+        String uuid = initialBundle.getString(uuidKey);
+        byte[] malformedBytes = new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9};
+        mFileDiskHandler.putBytes(uuid, malformedBytes);
+
+        // Originally, a new empty target does not contain the same data as the original target.
+        SampleTarget finalTarget = new SampleTarget(null);
+        assertNotEquals(data, finalTarget.getData());
+        assertNotEquals(initialTarget, finalTarget);
+
+        BridgeDelegate newDelegate = buildBridgeDelegate();
+        newDelegate.restoreInstanceState(finalTarget, initialBundle);
+
+        // After restoring, the final target still has no data and is not equal to the initial
+        // target
+        assertNull(finalTarget.getData());
+        assertNotEquals(initialTarget, finalTarget);
+    }
+
+    @Test
+    public void restoreInstanceState_differentInstance_truncatedData() {
+        // Should not restore the data to the final target and should not throw an exception.
+        Data data = new Data("Text");
+        SampleTarget initialTarget = new SampleTarget(data);
+        Bundle initialBundle = new Bundle();
+
+        mDelegate.saveInstanceState(initialTarget, initialBundle);
+
+        // Get the data written to disk
+        String uuidKey = String.format("uuid_%s", initialTarget.getClass().getName());
+        String uuid = initialBundle.getString(uuidKey);
+        byte[] originalBytes = mFileDiskHandler.getBytes(uuid);
+        byte[] truncatedBytes = new byte[originalBytes.length - 4];
+
+        // Overwrite the data with a truncated copy
+        System.arraycopy(originalBytes, 0, truncatedBytes, 0, truncatedBytes.length);
+        mFileDiskHandler.putBytes(uuid, truncatedBytes);
+
+        // Originally, a new empty target does not contain the same data as the original target.
+        SampleTarget finalTarget = new SampleTarget(null);
+        assertNotEquals(data, finalTarget.getData());
+        assertNotEquals(initialTarget, finalTarget);
+
+        BridgeDelegate newDelegate = buildBridgeDelegate();
+        newDelegate.restoreInstanceState(finalTarget, initialBundle);
+
+        // After restoring, the final target still has no data and is not equal to the initial
+        // target
+        assertNull(finalTarget.getData());
+        assertNotEquals(initialTarget, finalTarget);
+    }
+
+    @Test
+    public void restoreInstanceState_differentInstance_validData() {
         // Should restore data by loading it from disk
         Data data = new Data("Text");
         SampleTarget initialTarget = new SampleTarget(data);

--- a/bridge/src/androidTest/java/com/livefront/bridge/BridgeDelegateTest.java
+++ b/bridge/src/androidTest/java/com/livefront/bridge/BridgeDelegateTest.java
@@ -1,0 +1,111 @@
+package com.livefront.bridge;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import com.livefront.bridge.disk.FileDiskHandler;
+import com.livefront.bridge.helper.Data;
+import com.livefront.bridge.helper.SampleTarget;
+import com.livefront.bridge.helper.Saveable;
+
+import org.junit.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class BridgeDelegateTest {
+
+    private final Context mContext = InstrumentationRegistry.getInstrumentation().getContext();
+    private final ExecutorService mExecutor = Executors.newCachedThreadPool();
+    private final FileDiskHandler mFileDiskHandler = new FileDiskHandler(mContext, mExecutor);
+    private final SavedStateHandler mSavedStateHandler = new SavedStateHandler() {
+        @Override
+        public void saveInstanceState(@NonNull Object target,
+                                      @NonNull Bundle state) {
+            ((Saveable) target).saveState(state);
+        }
+
+        @Override
+        public void restoreInstanceState(@NonNull Object target,
+                                         @Nullable Bundle state) {
+            ((Saveable) target).restoreState(state);
+        }
+    };
+    private final BridgeDelegate mDelegate = buildBridgeDelegate();
+
+    @Test
+    public void restoreInstanceState_differentInstance() {
+        // Should restore data by loading it from disk
+        Data data = new Data("Text");
+        SampleTarget initialTarget = new SampleTarget(data);
+        Bundle initialBundle = new Bundle();
+
+        mDelegate.saveInstanceState(initialTarget, initialBundle);
+
+        // Check that data is now persisted to disk
+        String uuidKey = String.format("uuid_%s", initialTarget.getClass().getName());
+        String uuid = initialBundle.getString(uuidKey);
+        assertNotNull(mFileDiskHandler.getBytes(uuid));
+
+        // Originally, a new empty target does not contain the same data as the original target.
+        SampleTarget finalTarget = new SampleTarget(null);
+        assertNotEquals(data, finalTarget.getData());
+        assertNotEquals(initialTarget, finalTarget);
+
+        BridgeDelegate newDelegate = buildBridgeDelegate();
+        newDelegate.restoreInstanceState(finalTarget, initialBundle);
+
+        // After restoring, the final target is the same as the original one.
+        assertEquals(data, finalTarget.getData());
+        assertEquals(initialTarget, finalTarget);
+    }
+
+    @Test
+    public void restoreInstanceState_sameInstance() {
+        // Should restore data by loading it from memory
+        Data data = new Data("Text");
+        SampleTarget initialTarget = new SampleTarget(data);
+        Bundle initialBundle = new Bundle();
+
+        mDelegate.saveInstanceState(initialTarget, initialBundle);
+
+        // Clear all data to prove we're getting it from memory
+        mFileDiskHandler.clearAll();
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            // no-op
+        }
+
+        // Originally, a new empty target does not contain the same data as the original target.
+        SampleTarget finalTarget = new SampleTarget(null);
+        assertNotEquals(data, finalTarget.getData());
+        assertNotEquals(initialTarget, finalTarget);
+
+        mDelegate.restoreInstanceState(finalTarget, initialBundle);
+
+        // After restoring, the final target is the same as the original one.
+        assertEquals(data, finalTarget.getData());
+        assertEquals(initialTarget, finalTarget);
+    }
+
+    //region Private helper methods
+    @NonNull
+    private BridgeDelegate buildBridgeDelegate() {
+        return new BridgeDelegate(
+                mContext,
+                Executors.newSingleThreadExecutor(),
+                mSavedStateHandler,
+                null);
+    }
+    //endregion Private helper methods
+}

--- a/bridge/src/androidTest/java/com/livefront/bridge/util/BundleUtilTest.java
+++ b/bridge/src/androidTest/java/com/livefront/bridge/util/BundleUtilTest.java
@@ -2,6 +2,7 @@ package com.livefront.bridge.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import android.os.Bundle;
@@ -14,6 +15,35 @@ public class BundleUtilTest {
 
     private static final String DATA_KEY = "data";
     private static final String SAMPLE_TEXT = "sample text";
+
+    @Test
+    public void fromBytes_malformedData() {
+        // Should return null and not throw an IllegalStateException
+        byte[] bytes = new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+        Bundle outputBundle = BundleUtil.fromBytes(bytes);
+
+        assertNull(outputBundle);
+    }
+
+    @Test
+    public void fromBytes_truncatedData() {
+        // Should return null and not throw an IllegalArgumentException
+
+        // Begin with valid data
+        Data sampleData = new Data(SAMPLE_TEXT);
+        Bundle bundle = new Bundle();
+        bundle.putParcelable(DATA_KEY, sampleData);
+        byte[] bytes = BundleUtil.toBytes(bundle);
+
+        // Derive data that truncates the valid data
+        byte[] truncatedBytes = new byte[bytes.length - 4];
+        System.arraycopy(bytes, 0, truncatedBytes, 0, truncatedBytes.length);
+
+        Bundle outputBundle = BundleUtil.fromBytes(truncatedBytes);
+
+        assertNull(outputBundle);
+    }
 
     @Test
     public void toBytes() {

--- a/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
+++ b/bridge/src/main/java/com/livefront/bridge/BridgeDelegate.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
+import android.util.Log;
 import android.view.View;
 
 import androidx.annotation.NonNull;
@@ -238,7 +239,12 @@ class BridgeDelegate {
         if (bytes == null) {
             return null;
         }
-        return BundleUtil.fromBytes(bytes);
+        Bundle bundle = BundleUtil.fromBytes(bytes);
+        if (bundle == null) {
+            Log.e("Bridge", "Unable to properly convert disk-persisted data to a Bundle. Some"
+                    + " state loss may occur.");
+        }
+        return bundle;
     }
 
     @SuppressLint("NewApi")

--- a/bridge/src/main/java/com/livefront/bridge/util/BundleUtil.java
+++ b/bridge/src/main/java/com/livefront/bridge/util/BundleUtil.java
@@ -5,6 +5,7 @@ import android.os.Parcel;
 import android.util.Base64;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Helper class for converting {@link Bundle} instances to and from bytes and encoded Strings.
@@ -45,17 +46,22 @@ public class BundleUtil {
      * Converts the given bytes to a {@link Bundle}.
      *
      * Note that if the bytes do not represent a {@code Bundle} that was previously converted with
-     * {@link #toBytes(Bundle)}, this process will likely fail.
+     * {@link #toBytes(Bundle)}, this process will likely fail and will return {@code null}.
      *
      * @param bytes The bytes to convert.
-     * @return The resulting {@code Bundle}.
+     * @return The resulting {@code Bundle} (or {@code null} if the conversion failed).
      */
-    @NonNull
+    @Nullable
     public static Bundle fromBytes(byte[] bytes) {
         Parcel parcel = Parcel.obtain();
         parcel.unmarshall(bytes, 0, bytes.length);
         parcel.setDataPosition(0);
-        Bundle bundle = parcel.readBundle(BundleUtil.class.getClassLoader());
+        Bundle bundle;
+        try {
+            bundle = parcel.readBundle(BundleUtil.class.getClassLoader());
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            bundle = null;
+        }
         parcel.recycle();
         return bundle;
     }
@@ -64,12 +70,13 @@ public class BundleUtil {
      * Converts the given Base64 encoded String to a {@link Bundle}.
      *
      * Note that if the String does not represent a {@code Bundle} that was previously converted
-     * with {@link #toEncodedString(Bundle)} (Bundle)}, this process will likely fail.
+     * with {@link #toEncodedString(Bundle)} (Bundle)}, this process will likely fail and will
+     * return {@code null}.
      *
      * @param encodedString The bytes to convert.
-     * @return The resulting {@code Bundle}.
+     * @return The resulting {@code Bundle} (or {@code null} if the conversion failed).
      */
-    @NonNull
+    @Nullable
     public static Bundle fromEncodedString(@NonNull String encodedString) {
         return fromBytes(Base64.decode(encodedString, 0));
     }


### PR DESCRIPTION
This PR adds safer handling when reading data back from disk when using `BundleUtil.fromBytes`. This is to address issues raised by https://github.com/livefront/bridge/issues/72 that seem to point to cases where data was partially written to disk. In these cases the existing implementation of `BundleUtil.fromBytes` throws either an `IllegalArgumentException` or `IllegalStateException`. Now it simply returns `null` in these cases. I am now also printing off an error log in these scenarios to indicate that some state loss has occurred.