### PR TITLE
Minor clear all update

### DIFF
--- a/bridge/src/androidTest/java/com/livefront/bridge/BridgeTest.java
+++ b/bridge/src/androidTest/java/com/livefront/bridge/BridgeTest.java
@@ -2,22 +2,34 @@ package com.livefront.bridge;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import android.content.Context;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.test.platform.app.InstrumentationRegistry;
 
+import com.livefront.bridge.disk.FileDiskHandler;
 import com.livefront.bridge.helper.Data;
 import com.livefront.bridge.helper.SampleTarget;
 import com.livefront.bridge.helper.Saveable;
+import com.livefront.bridge.util.BundleUtil;
 
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 public class BridgeTest {
+
+    private final Context mContext = InstrumentationRegistry.getInstrumentation().getContext();
+    private final ExecutorService mExecutor = Executors.newCachedThreadPool();
+
     @Before
     public void setUp() {
         Bridge.initialize(
@@ -35,6 +47,70 @@ public class BridgeTest {
                         ((Saveable) target).restoreState(state);
                     }
                 });
+    }
+
+    @Test
+    public void clearAll_withDataPersistedFromCurrentSession() {
+        // Should clear any previously-stored data from disk and memory.
+
+        // Populate the data using a direct call to Bridge.saveInstanceState.
+        Data data = new Data("Text");
+        SampleTarget initialTarget = new SampleTarget(data);
+        Bundle initialBundle = new Bundle();
+        Bridge.saveInstanceState(initialTarget, initialBundle);
+
+        // Confirm there is data stored to disk
+        String uuidKey = String.format("uuid_%s", initialTarget.getClass().getName());
+        String uuid = initialBundle.getString(uuidKey);
+        assertNotNull(uuid);
+        assertNotNull(buildFileDiskHandler().getBytes(uuid));
+
+        Bridge.clearAll(mContext);
+
+        // Wait for any clearing to happen on a background thread.
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            // no-op
+        }
+
+        // Confirm there is now no data stored to disk.
+        assertNull(buildFileDiskHandler().getBytes(uuid));
+
+        SampleTarget finalTarget = new SampleTarget(null);
+        assertNull(finalTarget.getData());
+        assertNotEquals(initialTarget, finalTarget);
+
+        // Confirm data can not be restored from memory
+        Bridge.restoreInstanceState(finalTarget, initialBundle);
+        assertNull(finalTarget.getData());
+        assertNotEquals(initialTarget, finalTarget);
+    }
+
+    @Test
+    public void clearAll_withDataPersistedFromPreviousSession() {
+        // Should clear any previously-stored data from disk
+
+        // Populate the data indirectly using a FileDiskHandler to avoid creating a static
+        // BridgeDelegate instance.
+        String uuid = "bb63d01f-287f-4fd3-b2ed-92a07da40a95";
+        Bundle bundle = new Bundle();
+        bundle.putString("key", "value");
+        byte[] bytes = BundleUtil.toBytes(bundle);
+        buildFileDiskHandler().putBytes(uuid, bytes);
+        assertNotNull(buildFileDiskHandler().getBytes(uuid));
+
+        Bridge.clearAll(mContext);
+
+        // Wait for any clearing to happen on a background thread.
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            // no-op
+        }
+
+        // Confirm there is now no data stored to disk.
+        assertNull(buildFileDiskHandler().getBytes(uuid));
     }
 
     @Test
@@ -81,4 +157,11 @@ public class BridgeTest {
         assertNotEquals(data, additionalTarget.getData());
         assertNotEquals(initialTarget, additionalTarget);
     }
+
+    //region Private helper methods
+    @NonNull
+    private FileDiskHandler buildFileDiskHandler() {
+        return new FileDiskHandler(mContext, mExecutor);
+    }
+    //endregion Private helper methods
 }

--- a/bridge/src/androidTest/java/com/livefront/bridge/helper/SampleTarget.java
+++ b/bridge/src/androidTest/java/com/livefront/bridge/helper/SampleTarget.java
@@ -21,7 +21,7 @@ public final class SampleTarget implements Saveable {
         mData = data;
     }
 
-    @NonNull
+    @Nullable
     public Data getData() {
         return mData;
     }

--- a/bridge/src/main/java/com/livefront/bridge/Bridge.java
+++ b/bridge/src/main/java/com/livefront/bridge/Bridge.java
@@ -9,6 +9,8 @@ import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.livefront.bridge.disk.FileDiskHandler;
+
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -42,15 +44,17 @@ public class Bridge {
      * Clears all data from disk and memory. Does not require a call to {@link #initialize(Context,
      * SavedStateHandler)}.
      */
-    public static void clearAll(@NonNull Context context) {
-        BridgeDelegate delegate = sDelegate != null
-                ? sDelegate
-                : new BridgeDelegate(
-                        context,
-                        sExecutorService,
-                        new NoOpSavedStateHandler(),
-                        null);
-        delegate.clearAll();
+    public static void clearAll(@NonNull final Context context) {
+        if (sDelegate != null) {
+            sDelegate.clearAll();
+        } else {
+            sExecutorService.execute(new Runnable() {
+                @Override
+                public void run() {
+                    new FileDiskHandler(context, sExecutorService).clearAll();
+                }
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
This PR updates the `Bridge.clearAll` method very slightly to directly use a `FileDiskHandler` to clear data when there is no `sDelegate` instance. My thinking behind this change was that (a) it just gets more directly to what needs to be done and (b) it avoids the one-off `BridgeDelegate` instance from unnecessarily being registered as an application lifecycle listener.