### PR TITLE
Prepare for v2.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+Version 2.0.2 *(2021-04-19)*
+----------------------------
+
+ * Ensured that malformed or incomplete data saved to disk does not result in an exception when attempting to restore state.
+
 Version 2.0.1 *(2021-03-31)*
 ----------------------------
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A library for avoiding TransactionTooLargeException during state saving and rest
 * [Limitations](#limitations)
 * [Testing](#testing)
 * [License](#license)
-* [Javadoc](https://jitpack.io/com/github/livefront/bridge/v2.0.1/javadoc/index.html)
+* [Javadoc](https://jitpack.io/com/github/livefront/bridge/v2.0.2/javadoc/index.html)
 
 <a name="motivation"></a>
 ## Motivation
@@ -140,7 +140,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.livefront:bridge:v2.0.1'
+    implementation 'com.github.livefront:bridge:v2.0.2'
 }
 ```
 


### PR DESCRIPTION
This PR updates the REAMDE and CHANGELOG files in preparation of the v2.0.2 release. This includes:

- A fix for exceptions thrown when reading bad data (https://github.com/livefront/bridge/pull/73).
- A minor tweak to how `Bridge.clearAll` is handled when no `BridgeDelegate` instance is available (https://github.com/livefront/bridge/pull/74).
